### PR TITLE
feat: bootstrap tutor loop hub MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules
+.env
+.env.*
+dist
+.next
+coverage
+.prisma
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,1 +1,89 @@
-# start
+# Tutor Loop Hub
+
+Full-stack monorepo delivering the minimum viable loops between students, tutors, and parents.
+
+## Overview
+- **Apps**
+  - `apps/api`: Node.js 20 + Express + Prisma API with PostgreSQL (docker-compose ready).
+  - `apps/web`: Next.js 14 App Router + Tailwind UI providing one-click decision screens per role.
+- **Domains covered**
+  - S↔T: assignments, submissions, reviews, SLA tracking, session notes.
+  - P↔T: calendar proposals/confirmations, attendance with signatures, invoices, reports.
+  - S↔P: daily digest, encouragements, visibility controls, policy exception handling.
+- **Security**: email/password auth with JWT and role-based guards.
+- **Observability**: every status transition, policy application, signature, or financial event records an audit log.
+
+## Prerequisites
+- Node.js ≥ 20
+- npm 9+
+- Docker (for PostgreSQL via `docker-compose`)
+
+## Quick start
+```bash
+# 1. Install dependencies
+npm install
+
+# 2. Start Postgres locally
+docker-compose up -d
+
+# 3. Apply database schema and seed baseline data (tutor/parent/student accounts)
+npm run prisma:migrate
+npm run prisma:seed
+
+# 4. Generate Prisma client (runs automatically on install, re-run if needed)
+npm run prisma:migrate
+
+# 5. Run the API
+npm run dev:api
+
+# 6. Run the web app (in a separate terminal)
+npm run dev:web
+```
+The API listens on `http://localhost:4000` by default. The web app runs on `http://localhost:3000`.
+
+### Default credentials
+| Role   | Email                | Password     |
+|--------|----------------------|--------------|
+| Tutor  | tutor@example.com    | password123  |
+| Parent | parent@example.com   | password123  |
+| Student| student@example.com  | password123  |
+
+## Environment variables
+Copy `apps/api/.env.example` to `.env` (or `.env.local`) and adjust as needed.
+
+### API (`apps/api`)
+- `DATABASE_URL` – connection string for PostgreSQL (defaults to docker-compose instance).
+- `JWT_SECRET` – secret for signing JWT tokens.
+
+### Web (`apps/web`)
+Set optional environment variables to surface live API data instead of demo placeholders:
+- `NEXT_PUBLIC_API_URL` – base URL of the API (defaults to `http://localhost:4000`).
+- `NEXT_PUBLIC_STUDENT_ID`, `NEXT_PUBLIC_STUDENT_TOKEN`
+- `NEXT_PUBLIC_TUTOR_TOKEN`
+- `NEXT_PUBLIC_PARENT_TOKEN`
+
+You can retrieve tokens by hitting `POST /auth/login` on the API.
+
+## Testing
+End-to-end integration tests (Supertest + Jest) cover the critical loops:
+```bash
+npm test
+```
+The Jest global setup runs Prisma migrations and seeds automatically before executing tests.
+
+## Database utilities
+- `npm run prisma:migrate` – applies migrations (`prisma migrate deploy`).
+- `npm run prisma:seed` – re-seeds the database with baseline fixtures (assignment, submission, note, calendar proposals, policy).
+
+## Front-end notes
+- Tailwind is configured in `apps/web/tailwind.config.ts`.
+- Role dashboards surface loading/error/empty states and keep actions to “one screen, one decision”.
+- Demo data appears when live API tokens are not provided.
+
+## Changelog
+- Implemented Express API with Prisma schema covering assignments, submissions, sessions, calendar, attendance, invoices, reports, digests, encouragements, visibility, and policy exceptions.
+- Added JWT auth, role-based middleware, audit logging helper, and Supertest scenario validating full S↔T, P↔T, S↔P loops.
+- Provisioned docker-compose Postgres, Prisma migrations, and seed data (tutor/parent/student trio plus baseline artifacts).
+- Delivered Next.js role dashboards, assignment/invoice detail pages, shared UI components, and safe API client with demo fallbacks.
+- Documented setup, environment, testing, and change history in this README.
+- Tightened API surface with validated resubmission payloads, parent/tutor-only invoice retrieval, and committed the initial Prisma migration for deploy automation.

--- a/apps/api/.eslintrc.cjs
+++ b/apps/api/.eslintrc.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    es2021: true,
+    jest: true
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: './tsconfig.json'
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'error',
+    'no-console': ['error', { allow: ['error'] }]
+  }
+};

--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.spec.ts'],
+  maxWorkers: 1,
+  globalSetup: '<rootDir>/tests/setup.ts',
+  globalTeardown: '<rootDir>/tests/teardown.ts'
+};
+
+export default config;

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@start/api",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "build": "tsc -p tsconfig.build.json",
+    "start": "node dist/index.js",
+    "test": "jest --runInBand",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate deploy",
+    "prisma:seed": "prisma db seed"
+  },
+  "dependencies": {
+    "@prisma/client": "5.13.0",
+    "bcryptjs": "2.4.3",
+    "cors": "2.8.5",
+    "date-fns": "3.6.0",
+    "dotenv": "16.4.5",
+    "express": "4.19.2",
+    "jsonwebtoken": "9.0.2",
+    "pdfkit": "0.13.0",
+    "zod": "3.22.4"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "2.4.2",
+    "@types/express": "4.17.21",
+    "@types/jest": "29.5.12",
+    "@types/jsonwebtoken": "9.0.6",
+    "@types/node": "20.11.30",
+    "@types/pdfkit": "0.13.6",
+    "@types/supertest": "2.0.16",
+    "eslint": "8.57.0",
+    "eslint-config-prettier": "9.1.0",
+    "@typescript-eslint/eslint-plugin": "7.2.0",
+    "@typescript-eslint/parser": "7.2.0",
+    "jest": "29.7.0",
+    "supertest": "6.3.4",
+    "ts-jest": "29.1.1",
+    "ts-node": "10.9.2",
+    "ts-node-dev": "2.0.0",
+    "typescript": "5.4.2"
+  }
+}

--- a/apps/api/prisma/migrations/20240515120000_init/migration.sql
+++ b/apps/api/prisma/migrations/20240515120000_init/migration.sql
@@ -1,0 +1,262 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('Student', 'Parent', 'Tutor');
+
+-- CreateEnum
+CREATE TYPE "RelationshipType" AS ENUM ('S-P', 'S-T', 'P-T');
+
+-- CreateEnum
+CREATE TYPE "AssignmentDifficulty" AS ENUM ('E', 'M', 'H');
+
+-- CreateEnum
+CREATE TYPE "AssignmentStatus" AS ENUM ('Open', 'Submitted', 'Reviewed', 'Resubmitted', 'Finalized');
+
+-- CreateEnum
+CREATE TYPE "SubmissionStatus" AS ENUM ('Submitted', 'NeedsResubmit', 'Approved');
+
+-- CreateEnum
+CREATE TYPE "SessionVisibility" AS ENUM ('S', 'SP', 'ST', 'SPT');
+
+-- CreateEnum
+CREATE TYPE "CalendarStatus" AS ENUM ('Proposed', 'Confirmed', 'Rescheduled', 'Cancelled');
+
+-- CreateEnum
+CREATE TYPE "InvoiceStatus" AS ENUM ('Issued', 'Paid', 'Voided');
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "role" "Role" NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Relationship" (
+    "id" TEXT NOT NULL,
+    "aUserId" TEXT NOT NULL,
+    "bUserId" TEXT NOT NULL,
+    "type" "RelationshipType" NOT NULL,
+    "consent" BOOLEAN NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Relationship_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Assignment" (
+    "id" TEXT NOT NULL,
+    "tutorId" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "goal" TEXT NOT NULL,
+    "difficulty" "AssignmentDifficulty" NOT NULL,
+    "dueAt" TIMESTAMP(3) NOT NULL,
+    "rubricId" TEXT,
+    "modelAnswerRef" TEXT,
+    "status" "AssignmentStatus" NOT NULL DEFAULT 'Open',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Assignment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Submission" (
+    "id" TEXT NOT NULL,
+    "assignmentId" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "version" INTEGER NOT NULL,
+    "files" JSONB NOT NULL,
+    "coverMeta" JSONB NOT NULL,
+    "status" "SubmissionStatus" NOT NULL DEFAULT 'Submitted',
+    "rubricScore" JSONB,
+    "comment" TEXT,
+    "requestedResubmit" BOOLEAN NOT NULL DEFAULT false,
+    "reviewDurationSeconds" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "reviewedAt" TIMESTAMP(3),
+    CONSTRAINT "Submission_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SessionNote" (
+    "id" TEXT NOT NULL,
+    "tutorId" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "summary" TEXT NOT NULL,
+    "issues" JSONB NOT NULL,
+    "nextActions" JSONB NOT NULL,
+    "visibilityScope" "SessionVisibility" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "SessionNote_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AttendanceLog" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT,
+    "sessionDate" TIMESTAMP(3) NOT NULL,
+    "startTs" TIMESTAMP(3) NOT NULL,
+    "endTs" TIMESTAMP(3) NOT NULL,
+    "minutes" INTEGER NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "tutorId" TEXT NOT NULL,
+    "confirmedByParent" BOOLEAN NOT NULL DEFAULT false,
+    "signatureTs" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "AttendanceLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Invoice" (
+    "id" TEXT NOT NULL,
+    "period" TEXT NOT NULL,
+    "parentId" TEXT NOT NULL,
+    "lineItems" JSONB NOT NULL,
+    "total" DECIMAL(10, 2) NOT NULL,
+    "status" "InvoiceStatus" NOT NULL DEFAULT 'Issued',
+    "issuedAt" TIMESTAMP(3) NOT NULL,
+    "paidAt" TIMESTAMP(3),
+    CONSTRAINT "Invoice_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Report" (
+    "id" TEXT NOT NULL,
+    "period" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "KPIs" JSONB NOT NULL,
+    "highlights" JSONB NOT NULL,
+    "nextPlan" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Report_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CalendarEvent" (
+    "id" TEXT NOT NULL,
+    "participants" JSONB NOT NULL,
+    "start" TIMESTAMP(3) NOT NULL,
+    "end" TIMESTAMP(3) NOT NULL,
+    "status" "CalendarStatus" NOT NULL DEFAULT 'Proposed',
+    "policyRef" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "tutorId" TEXT,
+    "studentId" TEXT,
+    "parentId" TEXT,
+    CONSTRAINT "CalendarEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Policy" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "rules" JSONB NOT NULL,
+    "version" INTEGER NOT NULL,
+    "effectiveFrom" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Policy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Encouragement" (
+    "id" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "parentId" TEXT NOT NULL,
+    "templateId" TEXT,
+    "message" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Encouragement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "VisibilitySetting" (
+    "id" TEXT NOT NULL,
+    "entityRef" TEXT NOT NULL,
+    "scope" "SessionVisibility" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "VisibilitySetting_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" TEXT NOT NULL,
+    "actorId" TEXT,
+    "entity" TEXT NOT NULL,
+    "entityId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "fromState" TEXT,
+    "toState" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Notification" (
+    "id" TEXT NOT NULL,
+    "recipientId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "isRead" BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VisibilitySetting_entityRef_key" ON "VisibilitySetting"("entityRef");
+
+-- AddForeignKey
+ALTER TABLE "Relationship" ADD CONSTRAINT "Relationship_aUserId_fkey" FOREIGN KEY ("aUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Relationship" ADD CONSTRAINT "Relationship_bUserId_fkey" FOREIGN KEY ("bUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Assignment" ADD CONSTRAINT "Assignment_tutorId_fkey" FOREIGN KEY ("tutorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Assignment" ADD CONSTRAINT "Assignment_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Submission" ADD CONSTRAINT "Submission_assignmentId_fkey" FOREIGN KEY ("assignmentId") REFERENCES "Assignment"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Submission" ADD CONSTRAINT "Submission_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SessionNote" ADD CONSTRAINT "SessionNote_tutorId_fkey" FOREIGN KEY ("tutorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SessionNote" ADD CONSTRAINT "SessionNote_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AttendanceLog" ADD CONSTRAINT "AttendanceLog_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AttendanceLog" ADD CONSTRAINT "AttendanceLog_tutorId_fkey" FOREIGN KEY ("tutorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AttendanceLog" ADD CONSTRAINT "AttendanceLog_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "CalendarEvent"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invoice" ADD CONSTRAINT "Invoice_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Report" ADD CONSTRAINT "Report_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Encouragement" ADD CONSTRAINT "Encouragement_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Encouragement" ADD CONSTRAINT "Encouragement_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_actorId_fkey" FOREIGN KEY ("actorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Notification" ADD CONSTRAINT "Notification_recipientId_fkey" FOREIGN KEY ("recipientId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/migration_lock.toml
+++ b/apps/api/prisma/migrations/migration_lock.toml
@@ -1,0 +1,2 @@
+# Prisma Migrate lockfile
+provider = "postgresql"

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1,0 +1,248 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum Role {
+  Student
+  Parent
+  Tutor
+}
+
+enum RelationshipType {
+  S_P @map("S-P")
+  S_T @map("S-T")
+  P_T @map("P-T")
+}
+
+enum AssignmentDifficulty {
+  E
+  M
+  H
+}
+
+enum AssignmentStatus {
+  Open
+  Submitted
+  Reviewed
+  Resubmitted
+  Finalized
+}
+
+enum SubmissionStatus {
+  Submitted
+  NeedsResubmit
+  Approved
+}
+
+enum SessionVisibility {
+  S
+  SP
+  ST
+  SPT
+}
+
+enum CalendarStatus {
+  Proposed
+  Confirmed
+  Rescheduled
+  Cancelled
+}
+
+enum InvoiceStatus {
+  Issued
+  Paid
+  Voided
+}
+
+model User {
+  id                     String          @id @default(cuid())
+  email                  String          @unique
+  passwordHash           String
+  role                   Role
+  name                   String
+  createdAt              DateTime        @default(now())
+  relationshipsA         Relationship[]  @relation("AUser")
+  relationshipsB         Relationship[]  @relation("BUser")
+  tutorAssignments       Assignment[]    @relation("TutorAssignments")
+  studentAssignments     Assignment[]    @relation("StudentAssignments")
+  submissions            Submission[]
+  tutorSessionNotes      SessionNote[]   @relation("TutorSessionNotes")
+  studentSessionNotes    SessionNote[]   @relation("StudentSessionNotes")
+  studentAttendance      AttendanceLog[] @relation("StudentAttendance")
+  tutorAttendance        AttendanceLog[] @relation("TutorAttendance")
+  invoices               Invoice[]       @relation("ParentInvoices")
+  reports                Report[]
+  encouragementsSent     Encouragement[] @relation("ParentEncouragements")
+  encouragementsReceived Encouragement[] @relation("StudentEncouragements")
+  notifications          Notification[]
+  auditLogs              AuditLog[]
+}
+
+model Relationship {
+  id        String           @id @default(cuid())
+  aUserId   String
+  bUserId   String
+  type      RelationshipType
+  consent   Boolean
+  createdAt DateTime         @default(now())
+  aUser     User             @relation("AUser", fields: [aUserId], references: [id])
+  bUser     User             @relation("BUser", fields: [bUserId], references: [id])
+}
+
+model Assignment {
+  id             String             @id @default(cuid())
+  tutorId        String
+  studentId      String
+  title          String
+  goal           String
+  difficulty     AssignmentDifficulty
+  dueAt          DateTime
+  rubricId       String?
+  modelAnswerRef String?
+  status         AssignmentStatus   @default(Open)
+  createdAt      DateTime           @default(now())
+  submissions    Submission[]
+  tutor          User               @relation("TutorAssignments", fields: [tutorId], references: [id])
+  student        User               @relation("StudentAssignments", fields: [studentId], references: [id])
+}
+
+model Submission {
+  id                    String           @id @default(cuid())
+  assignmentId          String
+  studentId             String
+  version               Int
+  files                 Json
+  coverMeta             Json
+  status                SubmissionStatus @default(Submitted)
+  rubricScore           Json?
+  comment               String?
+  requestedResubmit     Boolean          @default(false)
+  reviewDurationSeconds Int?
+  createdAt             DateTime         @default(now())
+  reviewedAt            DateTime?
+  assignment            Assignment       @relation(fields: [assignmentId], references: [id])
+  student               User             @relation(fields: [studentId], references: [id])
+}
+
+model SessionNote {
+  id              String            @id @default(cuid())
+  tutorId         String
+  studentId       String
+  date            DateTime
+  summary         String
+  issues          Json
+  nextActions     Json
+  visibilityScope SessionVisibility
+  createdAt       DateTime          @default(now())
+  tutor           User              @relation("TutorSessionNotes", fields: [tutorId], references: [id])
+  student         User              @relation("StudentSessionNotes", fields: [studentId], references: [id])
+}
+
+model AttendanceLog {
+  id                String        @id @default(cuid())
+  eventId           String?
+  sessionDate       DateTime
+  startTs           DateTime
+  endTs             DateTime
+  minutes           Int
+  studentId         String
+  tutorId           String
+  confirmedByParent Boolean       @default(false)
+  signatureTs       DateTime?
+  createdAt         DateTime      @default(now())
+  student           User          @relation("StudentAttendance", fields: [studentId], references: [id])
+  tutor             User          @relation("TutorAttendance", fields: [tutorId], references: [id])
+  event             CalendarEvent? @relation(fields: [eventId], references: [id])
+}
+
+model Invoice {
+  id       String        @id @default(cuid())
+  period   String
+  parentId String
+  lineItems Json
+  total    Decimal       @db.Decimal(10, 2)
+  status   InvoiceStatus @default(Issued)
+  issuedAt DateTime
+  paidAt   DateTime?
+  parent   User          @relation("ParentInvoices", fields: [parentId], references: [id])
+}
+
+model Report {
+  id        String   @id @default(cuid())
+  period    String
+  studentId String
+  KPIs      Json
+  highlights Json
+  nextPlan  Json
+  createdAt DateTime @default(now())
+  student   User     @relation(fields: [studentId], references: [id])
+}
+
+model CalendarEvent {
+  id           String         @id @default(cuid())
+  participants Json
+  start        DateTime
+  end          DateTime
+  status       CalendarStatus @default(Proposed)
+  policyRef    String?
+  createdAt    DateTime       @default(now())
+  tutorId      String?
+  studentId    String?
+  parentId     String?
+  attendance   AttendanceLog[]
+}
+
+model Policy {
+  id            String   @id @default(cuid())
+  title         String
+  rules         Json
+  version       Int
+  effectiveFrom DateTime
+  createdAt     DateTime @default(now())
+}
+
+model Encouragement {
+  id         String   @id @default(cuid())
+  studentId  String
+  parentId   String
+  templateId String?
+  message    String?
+  createdAt  DateTime @default(now())
+  student    User     @relation("StudentEncouragements", fields: [studentId], references: [id])
+  parent     User     @relation("ParentEncouragements", fields: [parentId], references: [id])
+}
+
+model VisibilitySetting {
+  id        String            @id @default(cuid())
+  entityRef String            @unique
+  scope     SessionVisibility
+  createdAt DateTime          @default(now())
+}
+
+model AuditLog {
+  id        String   @id @default(cuid())
+  actorId   String?
+  entity    String
+  entityId  String
+  action    String
+  fromState String?
+  toState   String?
+  metadata  Json?
+  createdAt DateTime @default(now())
+  actor     User?    @relation(fields: [actorId], references: [id])
+}
+
+model Notification {
+  id          String   @id @default(cuid())
+  recipientId String
+  type        String
+  payload     Json
+  createdAt   DateTime @default(now())
+  isRead      Boolean  @default(false)
+  recipient   User     @relation(fields: [recipientId], references: [id])
+}

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,0 +1,167 @@
+import {
+  PrismaClient,
+  Role,
+  AssignmentDifficulty,
+  AssignmentStatus,
+  SubmissionStatus,
+  SessionVisibility,
+  CalendarStatus,
+  RelationshipType
+} from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+async function main(): Promise<void> {
+  await prisma.auditLog.deleteMany();
+  await prisma.notification.deleteMany();
+  await prisma.encouragement.deleteMany();
+  await prisma.attendanceLog.deleteMany();
+  await prisma.calendarEvent.deleteMany();
+  await prisma.sessionNote.deleteMany();
+  await prisma.submission.deleteMany();
+  await prisma.assignment.deleteMany();
+  await prisma.report.deleteMany();
+  await prisma.invoice.deleteMany();
+  await prisma.relationship.deleteMany();
+  await prisma.policy.deleteMany();
+  await prisma.visibilitySetting.deleteMany();
+  await prisma.user.deleteMany();
+
+  const password = await bcrypt.hash('password123', 10);
+
+  const tutor = await prisma.user.create({
+    data: {
+      email: 'tutor@example.com',
+      passwordHash: password,
+      role: Role.Tutor,
+      name: 'Tutor A'
+    }
+  });
+
+  const parent = await prisma.user.create({
+    data: {
+      email: 'parent@example.com',
+      passwordHash: password,
+      role: Role.Parent,
+      name: 'Parent P'
+    }
+  });
+
+  const student = await prisma.user.create({
+    data: {
+      email: 'student@example.com',
+      passwordHash: password,
+      role: Role.Student,
+      name: 'Student S'
+    }
+  });
+
+  await prisma.relationship.createMany({
+    data: [
+      { aUserId: student.id, bUserId: parent.id, type: RelationshipType.S_P, consent: true },
+      { aUserId: student.id, bUserId: tutor.id, type: RelationshipType.S_T, consent: true },
+      { aUserId: parent.id, bUserId: tutor.id, type: RelationshipType.P_T, consent: true }
+    ]
+  });
+
+  const policy = await prisma.policy.create({
+    data: {
+      title: 'Default Engagement Policy',
+      version: 1,
+      effectiveFrom: new Date(),
+      rules: {
+        late: { grace_minutes: 5, option: 'shorten' },
+        absence: { notice_hours: 12, charge_policy: '50_percent' },
+        make_up: { window_days: 14, slots: 'weekday_evening' }
+      }
+    }
+  });
+
+  const assignment = await prisma.assignment.create({
+    data: {
+      tutorId: tutor.id,
+      studentId: student.id,
+      title: 'Seed Essay',
+      goal: 'Write a 3 paragraph essay',
+      difficulty: AssignmentDifficulty.M,
+      dueAt: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000),
+      rubricId: 'rubric-1',
+      modelAnswerRef: 's3://answers/model.pdf',
+      status: AssignmentStatus.Open
+    }
+  });
+
+  await prisma.assignment.update({
+    where: { id: assignment.id },
+    data: { status: AssignmentStatus.Submitted }
+  });
+
+  await prisma.submission.create({
+    data: {
+      assignmentId: assignment.id,
+      studentId: student.id,
+      version: 1,
+      files: [{ name: 'essay.pdf', mime: 'application/pdf', url: 'https://example.com/essay.pdf' }],
+      coverMeta: { unit: 'Writing', pages: 2 },
+      status: SubmissionStatus.Submitted
+    }
+  });
+
+  await prisma.sessionNote.create({
+    data: {
+      tutorId: tutor.id,
+      studentId: student.id,
+      date: new Date(),
+      summary: 'Focused on thesis statements.',
+      issues: ['Time management'],
+      nextActions: ['Practice outlines'],
+      visibilityScope: SessionVisibility.SPT
+    }
+  });
+
+  const options = [1, 2, 3].map((offset) => ({
+    start: new Date(Date.now() + offset * 24 * 60 * 60 * 1000),
+    end: new Date(Date.now() + offset * 24 * 60 * 60 * 1000 + 60 * 60 * 1000)
+  });
+
+  for (const opt of options) {
+    await prisma.calendarEvent.create({
+      data: {
+        participants: [tutor.id, parent.id, student.id],
+        tutorId: tutor.id,
+        parentId: parent.id,
+        studentId: student.id,
+        start: opt.start,
+        end: opt.end,
+        status: CalendarStatus.Proposed
+      }
+    });
+  }
+
+  await prisma.visibilitySetting.create({
+    data: {
+      entityRef: `assignment:${assignment.id}`,
+      scope: SessionVisibility.SPT
+    }
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      actorId: tutor.id,
+      entity: 'Policy',
+      entityId: policy.id,
+      action: 'SEED_POLICY',
+      metadata: { source: 'seed' }
+    }
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,44 @@
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import authRoutes from './routes/auth';
+import assignmentRoutes from './routes/assignments';
+import submissionRoutes from './routes/submissions';
+import slaRoutes from './routes/sla';
+import sessionRoutes from './routes/session-notes';
+import calendarRoutes from './routes/calendar';
+import attendanceRoutes from './routes/attendance';
+import reportRoutes from './routes/reports';
+import invoiceRoutes from './routes/invoices';
+import digestRoutes from './routes/daily-digest';
+import encouragementRoutes from './routes/encouragement';
+import visibilityRoutes from './routes/visibility';
+import exceptionRoutes from './routes/exceptions';
+import { errorHandler } from './middleware/error';
+
+dotenv.config();
+
+export function createApp() {
+  const app = express();
+
+  app.use(cors());
+  app.use(express.json({ limit: '1mb' }));
+
+  app.use('/auth', authRoutes);
+  app.use('/assignments', assignmentRoutes);
+  app.use('/submissions', submissionRoutes);
+  app.use('/sla', slaRoutes);
+  app.use('/session-notes', sessionRoutes);
+  app.use('/calendar', calendarRoutes);
+  app.use('/attendance', attendanceRoutes);
+  app.use('/reports', reportRoutes);
+  app.use('/invoices', invoiceRoutes);
+  app.use('/daily-digest', digestRoutes);
+  app.use('/encourage', encouragementRoutes);
+  app.use('/visibility', visibilityRoutes);
+  app.use('/exceptions', exceptionRoutes);
+
+  app.use(errorHandler);
+
+  return app;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,0 +1,10 @@
+import { createApp } from './app';
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 4000;
+
+const app = createApp();
+
+app.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`API server listening on port ${PORT}`);
+});

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,0 +1,56 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { Role } from '@prisma/client';
+import { AppError } from '../utils/errors';
+
+type JwtPayload = {
+  sub: string;
+  role: Role;
+};
+
+export interface AuthenticatedRequest extends Request {
+  user?: {
+    id: string;
+    role: Role;
+  };
+}
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'supersecret';
+
+export function signToken(user: { id: string; role: Role }): string {
+  return jwt.sign({ sub: user.id, role: user.role }, JWT_SECRET, { expiresIn: '12h' });
+}
+
+export function requireAuth(req: AuthenticatedRequest, _res: Response, next: NextFunction): void {
+  const header = req.headers.authorization;
+  if (!header) {
+    throw new AppError(401, 'Missing authorization header');
+  }
+
+  const [, token] = header.split(' ');
+  if (!token) {
+    throw new AppError(401, 'Invalid authorization header');
+  }
+
+  try {
+    const payload = jwt.verify(token, JWT_SECRET) as JwtPayload;
+    req.user = { id: payload.sub, role: payload.role };
+    next();
+  } catch (error) {
+    throw new AppError(401, 'Invalid token', error);
+  }
+}
+
+export function requireRole(roles: Role[]) {
+  return (req: AuthenticatedRequest, _res: Response, next: NextFunction): void => {
+    if (!req.user) {
+      throw new AppError(401, 'Unauthorized');
+    }
+
+    if (!roles.includes(req.user.role)) {
+      throw new AppError(403, 'Forbidden');
+    }
+
+    next();
+  };
+}

--- a/apps/api/src/middleware/error.ts
+++ b/apps/api/src/middleware/error.ts
@@ -1,0 +1,11 @@
+import { NextFunction, Request, Response } from 'express';
+import { AppError } from '../utils/errors';
+
+export function errorHandler(error: unknown, _req: Request, res: Response, _next: NextFunction): Response {
+  if (error instanceof AppError) {
+    return res.status(error.status).json({ message: error.message, details: error.details ?? null });
+  }
+
+  console.error(error);
+  return res.status(500).json({ message: 'Internal server error' });
+}

--- a/apps/api/src/prisma.ts
+++ b/apps/api/src/prisma.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prisma = new PrismaClient({
+  log: ['error', 'warn']
+});

--- a/apps/api/src/routes/assignments.ts
+++ b/apps/api/src/routes/assignments.ts
@@ -1,0 +1,102 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { AssignmentStatus, Role, SessionVisibility } from '@prisma/client';
+import { requireAuth, requireRole, AuthenticatedRequest } from '../middleware/auth';
+import { prisma } from '../prisma';
+import { AppError } from '../utils/errors';
+import { ensureStudentVisibility, ensureTutorForStudent } from '../services/access';
+import { getVisibility, scopeAllows } from '../services/visibility';
+import { recordAudit } from '../services/audit';
+
+const router = Router();
+
+const createSchema = z.object({
+  studentId: z.string().cuid(),
+  title: z.string().min(1),
+  goal: z.string().min(1),
+  difficulty: z.enum(['E', 'M', 'H']),
+  dueAt: z.string(),
+  rubricId: z.string().optional(),
+  modelAnswerRef: z.string().optional(),
+  visibilityScope: z.enum(['S', 'SP', 'ST', 'SPT']).optional()
+});
+
+router.post('/', requireAuth, requireRole([Role.Tutor]), async (req: AuthenticatedRequest, res) => {
+  const parsed = createSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid assignment payload', parsed.error.flatten());
+  }
+
+  const { studentId, title, goal, difficulty, dueAt, rubricId, modelAnswerRef, visibilityScope } = parsed.data;
+  const tutorId = req.user!.id;
+
+  await ensureTutorForStudent(tutorId, studentId);
+
+  const dueDate = new Date(dueAt);
+  if (Number.isNaN(dueDate.getTime())) {
+    throw new AppError(400, 'Invalid due date');
+  }
+
+  const assignment = await prisma.assignment.create({
+    data: {
+      tutorId,
+      studentId,
+      title,
+      goal,
+      difficulty,
+      dueAt: dueDate,
+      rubricId,
+      modelAnswerRef,
+      status: AssignmentStatus.Open
+    }
+  });
+
+  await prisma.visibilitySetting.upsert({
+    where: { entityRef: `assignment:${assignment.id}` },
+    update: { scope: (visibilityScope as SessionVisibility | undefined) ?? SessionVisibility.SPT },
+    create: { entityRef: `assignment:${assignment.id}`, scope: (visibilityScope as SessionVisibility | undefined) ?? SessionVisibility.SPT }
+  });
+
+  await recordAudit({
+    actorId: tutorId,
+    entity: 'Assignment',
+    entityId: assignment.id,
+    action: 'ASSIGNMENT_CREATED',
+    toState: AssignmentStatus.Open
+  });
+
+  res.status(201).json({ assignment });
+});
+
+router.get('/students/:studentId', requireAuth, async (req: AuthenticatedRequest, res) => {
+  const { studentId } = req.params;
+  if (!studentId) {
+    throw new AppError(400, 'Student id required');
+  }
+
+  await ensureStudentVisibility(req.user!.id, req.user!.role, studentId);
+
+  const assignments = await prisma.assignment.findMany({
+    where: { studentId },
+    orderBy: { dueAt: 'asc' },
+    include: {
+      submissions: {
+        orderBy: { version: 'asc' }
+      },
+      tutor: true
+    }
+  });
+
+  const filtered = [];
+  for (const assignment of assignments) {
+    const scope = await getVisibility(`assignment:${assignment.id}`);
+    if (!scopeAllows(scope, req.user!.role)) {
+      continue;
+    }
+    filtered.push({ assignment, scope });
+  }
+
+  res.json({ assignments: filtered });
+});
+
+export default router;

--- a/apps/api/src/routes/attendance.ts
+++ b/apps/api/src/routes/attendance.ts
@@ -1,0 +1,103 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { Role } from '@prisma/client';
+import { requireAuth, requireRole, AuthenticatedRequest } from '../middleware/auth';
+import { ensureParentForStudent, ensureTutorForStudent } from '../services/access';
+import { prisma } from '../prisma';
+import { AppError } from '../utils/errors';
+import { recordAudit } from '../services/audit';
+
+const router = Router();
+
+const logSchema = z.object({
+  studentId: z.string().cuid(),
+  tutorId: z.string().cuid(),
+  startTs: z.string(),
+  endTs: z.string(),
+  minutes: z.number().int().positive()
+});
+
+router.post('/:eventId/log', requireAuth, requireRole([Role.Tutor]), async (req: AuthenticatedRequest, res) => {
+  const parsed = logSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid attendance payload', parsed.error.flatten());
+  }
+
+  const { eventId } = req.params;
+  const { studentId, tutorId, startTs, endTs, minutes } = parsed.data;
+  await ensureTutorForStudent(req.user!.id, studentId);
+
+  if (tutorId !== req.user!.id) {
+    throw new AppError(403, 'Tutor mismatch');
+  }
+
+  const event = await prisma.calendarEvent.findUnique({ where: { id: eventId } });
+  if (!event) {
+    throw new AppError(404, 'Event not found');
+  }
+
+  if (event.tutorId && event.tutorId !== tutorId) {
+    throw new AppError(403, 'Tutor not assigned to event');
+  }
+  if (event.studentId && event.studentId !== studentId) {
+    throw new AppError(403, 'Student not assigned to event');
+  }
+
+  const start = new Date(startTs);
+  const end = new Date(endTs);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || start >= end) {
+    throw new AppError(400, 'Invalid attendance timestamps');
+  }
+
+  const log = await prisma.attendanceLog.create({
+    data: {
+      eventId,
+      sessionDate: start,
+      startTs: start,
+      endTs: end,
+      minutes,
+      studentId,
+      tutorId,
+      confirmedByParent: false
+    }
+  });
+
+  await recordAudit({
+    actorId: req.user!.id,
+    entity: 'AttendanceLog',
+    entityId: log.id,
+    action: 'ATTENDANCE_RECORDED'
+  });
+
+  res.status(201).json({ attendance: log });
+});
+
+router.post('/:id/sign', requireAuth, requireRole([Role.Parent]), async (req: AuthenticatedRequest, res) => {
+  const { id } = req.params;
+  const log = await prisma.attendanceLog.findUnique({ where: { id } });
+  if (!log) {
+    throw new AppError(404, 'Attendance log not found');
+  }
+
+  await ensureParentForStudent(req.user!.id, log.studentId);
+
+  const updated = await prisma.attendanceLog.update({
+    where: { id },
+    data: {
+      confirmedByParent: true,
+      signatureTs: new Date()
+    }
+  });
+
+  await recordAudit({
+    actorId: req.user!.id,
+    entity: 'AttendanceLog',
+    entityId: id,
+    action: 'ATTENDANCE_SIGNED',
+    metadata: { signatureTs: updated.signatureTs }
+  });
+
+  res.json({ attendance: updated });
+});
+
+export default router;

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,0 +1,80 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import bcrypt from 'bcryptjs';
+import { prisma } from '../prisma';
+import { signToken } from '../middleware/auth';
+import { AppError } from '../utils/errors';
+import { recordAudit } from '../services/audit';
+
+const router = Router();
+
+const registerSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  role: z.enum(['Student', 'Parent', 'Tutor']),
+  name: z.string().min(1)
+});
+
+router.post('/register', async (req, res) => {
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid register payload', parsed.error.flatten());
+  }
+
+  const { email, password, role, name } = parsed.data;
+
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) {
+    throw new AppError(409, 'Email already registered');
+  }
+
+  const passwordHash = await bcrypt.hash(password, 10);
+  const user = await prisma.user.create({ data: { email, passwordHash, role, name } });
+  const token = signToken({ id: user.id, role: user.role });
+
+  await recordAudit({
+    actorId: user.id,
+    entity: 'User',
+    entityId: user.id,
+    action: 'REGISTER',
+    metadata: { role: user.role }
+  });
+
+  res.status(201).json({ token, user: { id: user.id, email: user.email, role: user.role, name: user.name } });
+});
+
+const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8)
+});
+
+router.post('/login', async (req, res) => {
+  const parsed = loginSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid login payload', parsed.error.flatten());
+  }
+
+  const { email, password } = parsed.data;
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    throw new AppError(401, 'Invalid credentials');
+  }
+
+  const match = await bcrypt.compare(password, user.passwordHash);
+  if (!match) {
+    throw new AppError(401, 'Invalid credentials');
+  }
+
+  const token = signToken({ id: user.id, role: user.role });
+
+  await recordAudit({
+    actorId: user.id,
+    entity: 'User',
+    entityId: user.id,
+    action: 'LOGIN'
+  });
+
+  res.json({ token, user: { id: user.id, email: user.email, role: user.role, name: user.name } });
+});
+
+export default router;

--- a/apps/api/src/routes/calendar.ts
+++ b/apps/api/src/routes/calendar.ts
@@ -1,0 +1,165 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { CalendarStatus, RelationshipType, Role } from '@prisma/client';
+import { requireAuth, requireRole, AuthenticatedRequest } from '../middleware/auth';
+import { ensureParentForStudent, ensureTutorForStudent, ensureParticipant } from '../services/access';
+import { prisma } from '../prisma';
+import { AppError } from '../utils/errors';
+import { recordAudit } from '../services/audit';
+
+const router = Router();
+
+const proposalSchema = z.object({
+  studentId: z.string().cuid(),
+  options: z
+    .array(
+      z.object({
+        start: z.string(),
+        end: z.string()
+      })
+    )
+    .min(3)
+});
+
+router.post('/proposals', requireAuth, requireRole([Role.Tutor]), async (req: AuthenticatedRequest, res) => {
+  const parsed = proposalSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid proposal payload', parsed.error.flatten());
+  }
+
+  const tutorId = req.user!.id;
+  const { studentId, options } = parsed.data;
+
+  await ensureTutorForStudent(tutorId, studentId);
+
+  const parentRelation = await prisma.relationship.findFirst({
+    where: { aUserId: studentId, type: RelationshipType.S_P, consent: true }
+  });
+  const parentId = parentRelation?.bUserId;
+
+  const events = [];
+  for (const option of options) {
+    const start = new Date(option.start);
+    const end = new Date(option.end);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || start >= end) {
+      throw new AppError(400, 'Invalid option times');
+    }
+
+    const event = await prisma.calendarEvent.create({
+      data: {
+        participants: [tutorId, studentId, parentId].filter(Boolean),
+        tutorId,
+        studentId,
+        parentId: parentId ?? undefined,
+        start,
+        end,
+        status: CalendarStatus.Proposed
+      }
+    });
+    await recordAudit({
+      actorId: tutorId,
+      entity: 'CalendarEvent',
+      entityId: event.id,
+      action: 'CALENDAR_PROPOSED'
+    });
+    events.push(event);
+  }
+
+  res.status(201).json({ events });
+});
+
+const confirmSchema = z.object({
+  eventId: z.string().cuid()
+});
+
+router.post('/confirm', requireAuth, requireRole([Role.Parent]), async (req: AuthenticatedRequest, res) => {
+  const parsed = confirmSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid confirm payload', parsed.error.flatten());
+  }
+
+  const event = await prisma.calendarEvent.findUnique({ where: { id: parsed.data.eventId } });
+  if (!event) {
+    throw new AppError(404, 'Event not found');
+  }
+
+  await ensureParticipant(req.user!.id, event.id);
+  await ensureParentForStudent(req.user!.id, event.studentId ?? '');
+
+  const overlapping = await prisma.calendarEvent.findMany({
+    where: {
+      id: { not: event.id },
+      status: CalendarStatus.Confirmed,
+      OR: [
+        { tutorId: event.tutorId ?? undefined },
+        { studentId: event.studentId ?? undefined },
+        { parentId: event.parentId ?? undefined }
+      ]
+    }
+  });
+
+  const conflict = overlapping.some((other) => other.start < event.end && other.end > event.start);
+
+  const updated = await prisma.calendarEvent.update({
+    where: { id: event.id },
+    data: { status: CalendarStatus.Confirmed }
+  });
+
+  await recordAudit({
+    actorId: req.user!.id,
+    entity: 'CalendarEvent',
+    entityId: event.id,
+    action: 'CALENDAR_CONFIRMED',
+    metadata: { conflict }
+  });
+
+  res.json({ event: updated, conflict });
+});
+
+const rescheduleSchema = z.object({
+  eventId: z.string().cuid(),
+  newStart: z.string(),
+  newEnd: z.string()
+});
+
+router.post('/reschedule', requireAuth, requireRole([Role.Tutor, Role.Parent]), async (req: AuthenticatedRequest, res) => {
+  const parsed = rescheduleSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid reschedule payload', parsed.error.flatten());
+  }
+
+  const { eventId, newStart, newEnd } = parsed.data;
+  const event = await prisma.calendarEvent.findUnique({ where: { id: eventId } });
+  if (!event) {
+    throw new AppError(404, 'Event not found');
+  }
+
+  await ensureParticipant(req.user!.id, eventId);
+
+  const start = new Date(newStart);
+  const end = new Date(newEnd);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || start >= end) {
+    throw new AppError(400, 'Invalid schedule window');
+  }
+
+  const updated = await prisma.calendarEvent.update({
+    where: { id: eventId },
+    data: {
+      start,
+      end,
+      status: CalendarStatus.Rescheduled
+    }
+  });
+
+  await recordAudit({
+    actorId: req.user!.id,
+    entity: 'CalendarEvent',
+    entityId: eventId,
+    action: 'CALENDAR_RESCHEDULED',
+    metadata: { previousStart: event.start, previousEnd: event.end }
+  });
+
+  res.json({ event: updated });
+});
+
+export default router;

--- a/apps/api/src/routes/daily-digest.ts
+++ b/apps/api/src/routes/daily-digest.ts
@@ -1,0 +1,99 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { AssignmentStatus, Role } from '@prisma/client';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth';
+import { ensureParentForStudent, ensureStudentVisibility } from '../services/access';
+import { prisma } from '../prisma';
+import { getVisibility, scopeAllows } from '../services/visibility';
+
+const router = Router();
+
+const querySchema = z.object({
+  relationship: z.enum(['S-P', 'S-T', 'P-T']),
+  studentId: z.string().cuid()
+});
+
+router.get('/', requireAuth, async (req: AuthenticatedRequest, res) => {
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json({ message: 'Invalid query' });
+    return;
+  }
+
+  const { relationship, studentId } = parsed.data;
+  if (relationship === 'S-P') {
+    if (req.user!.role === Role.Parent) {
+      await ensureParentForStudent(req.user!.id, studentId);
+    } else if (req.user!.role === Role.Student) {
+      await ensureStudentVisibility(req.user!.id, req.user!.role, studentId);
+    } else {
+      res.status(403).json({ message: 'Forbidden' });
+      return;
+    }
+  }
+
+  const lastSubmission = await prisma.submission.findFirst({
+    where: { studentId },
+    orderBy: { createdAt: 'desc' },
+    include: { assignment: true }
+  });
+
+  const notes = await prisma.sessionNote.findMany({
+    where: { studentId },
+    orderBy: { date: 'desc' }
+  });
+  const allowedNote = notes.find((note) => scopeAllows(note.visibilityScope, req.user!.role));
+
+  const now = new Date();
+  const upcomingAssignments = await prisma.assignment.findMany({
+    where: {
+      studentId,
+      dueAt: { lte: new Date(now.getTime() + 48 * 60 * 60 * 1000) }
+    },
+    include: { submissions: true }
+  });
+
+  const dueWithoutSubmission = [] as Array<{ id: string; title: string; dueAt: string }>;
+  for (const assignment of upcomingAssignments) {
+    const scope = await getVisibility(`assignment:${assignment.id}`);
+    if (!scopeAllows(scope, req.user!.role)) {
+      continue;
+    }
+    const hasRecentSubmission = assignment.submissions.length > 0;
+    if (!hasRecentSubmission || assignment.status !== AssignmentStatus.Finalized) {
+      dueWithoutSubmission.push({ id: assignment.id, title: assignment.title, dueAt: assignment.dueAt.toISOString() });
+    }
+  }
+
+  const unsignedAttendance = await prisma.attendanceLog.findMany({
+    where: { studentId, confirmedByParent: false }
+  });
+
+  const nextAssignment = await prisma.assignment.findFirst({
+    where: { studentId },
+    orderBy: { dueAt: 'asc' }
+  });
+
+  res.json({
+    highlights: {
+      last_submission: lastSubmission
+        ? { title: lastSubmission.assignment.title, submittedAt: lastSubmission.createdAt.toISOString() }
+        : null,
+      last_session_note: allowedNote ? { summary: allowedNote.summary, date: allowedNote.date.toISOString() } : null
+    },
+    risks: {
+      due_in_48h_without_submission: dueWithoutSubmission,
+      attendance_missing_signature: unsignedAttendance.map((log) => ({ id: log.id, sessionDate: log.sessionDate.toISOString() }))
+    },
+    next: {
+      next_due: nextAssignment
+        ? { id: nextAssignment.id, title: nextAssignment.title, dueAt: nextAssignment.dueAt.toISOString() }
+        : null,
+      checklist: {
+        exam_prep_items: (allowedNote?.nextActions as unknown[] | undefined) ?? []
+      }
+    }
+  });
+});
+
+export default router;

--- a/apps/api/src/routes/encouragement.ts
+++ b/apps/api/src/routes/encouragement.ts
@@ -1,0 +1,61 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { Role } from '@prisma/client';
+import { requireAuth, requireRole, AuthenticatedRequest } from '../middleware/auth';
+import { ensureParentForStudent } from '../services/access';
+import { prisma } from '../prisma';
+import { AppError } from '../utils/errors';
+import { recordAudit } from '../services/audit';
+
+const router = Router();
+
+const encourageSchema = z
+  .object({
+    studentId: z.string().cuid(),
+    templateId: z.string().optional(),
+    message: z.string().optional()
+  })
+  .refine((data) => data.templateId || data.message, { message: 'templateId or message required' });
+
+router.post('/', requireAuth, requireRole([Role.Parent]), async (req: AuthenticatedRequest, res) => {
+  const parsed = encourageSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid encouragement payload', parsed.error.flatten());
+  }
+
+  const parentId = req.user!.id;
+  const { studentId, templateId, message } = parsed.data;
+  await ensureParentForStudent(parentId, studentId);
+
+  const encouragement = await prisma.encouragement.create({
+    data: {
+      studentId,
+      parentId,
+      templateId,
+      message
+    }
+  });
+
+  await prisma.notification.create({
+    data: {
+      recipientId: studentId,
+      type: 'encouragement',
+      payload: {
+        encouragementId: encouragement.id,
+        templateId,
+        message
+      }
+    }
+  });
+
+  await recordAudit({
+    actorId: parentId,
+    entity: 'Encouragement',
+    entityId: encouragement.id,
+    action: 'ENCOURAGEMENT_SENT'
+  });
+
+  res.status(201).json({ encouragement });
+});
+
+export default router;

--- a/apps/api/src/routes/exceptions.ts
+++ b/apps/api/src/routes/exceptions.ts
@@ -1,0 +1,85 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { Role } from '@prisma/client';
+import { requireAuth, requireRole, AuthenticatedRequest } from '../middleware/auth';
+import { prisma } from '../prisma';
+import { AppError } from '../utils/errors';
+import { recordAudit } from '../services/audit';
+
+const router = Router();
+
+const exceptionSchema = z.object({
+  type: z.enum(['absence', 'late', 'make_up']),
+  context: z.record(z.unknown())
+});
+
+router.post('/apply', requireAuth, requireRole([Role.Tutor, Role.Parent]), async (req: AuthenticatedRequest, res) => {
+  const parsed = exceptionSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid exception payload', parsed.error.flatten());
+  }
+
+  const policy = await prisma.policy.findFirst({ orderBy: { effectiveFrom: 'desc' } });
+  if (!policy) {
+    throw new AppError(404, 'No policy configured');
+  }
+
+  const rules = policy.rules as {
+    late?: { grace_minutes?: number; option?: string };
+    absence?: { notice_hours?: number; charge_policy?: string };
+    make_up?: { window_days?: number; slots?: string };
+  };
+  let outcome: Record<string, unknown> = {};
+
+  switch (parsed.data.type) {
+    case 'late': {
+      const minutesLate = Number(parsed.data.context.minutesLate ?? 0);
+      const grace = Number(rules.late?.grace_minutes ?? 0);
+      const waived = minutesLate <= grace;
+      outcome = {
+        waived,
+        adjustment: waived ? 0 : minutesLate - grace,
+        option: rules.late?.option ?? 'standard'
+      };
+      break;
+    }
+    case 'absence': {
+      const noticeHours = Number(parsed.data.context.noticeHours ?? 0);
+      const requiredNotice = Number(rules.absence?.notice_hours ?? 0);
+      const chargePolicy = rules.absence?.charge_policy ?? 'full';
+      const chargeRate = chargePolicy === '50_percent' ? 0.5 : 1;
+      const waived = noticeHours >= requiredNotice;
+      outcome = {
+        waived,
+        chargeRate: waived ? 0 : chargeRate,
+        policy: chargePolicy
+      };
+      break;
+    }
+    case 'make_up': {
+      outcome = {
+        window_days: rules.make_up?.window_days ?? 0,
+        slots: rules.make_up?.slots ?? 'none'
+      };
+      break;
+    }
+    default:
+      throw new AppError(400, 'Unsupported exception type');
+  }
+
+  await recordAudit({
+    actorId: req.user!.id,
+    entity: 'Policy',
+    entityId: policy.id,
+    action: 'POLICY_EXCEPTION_APPLIED',
+    metadata: {
+      type: parsed.data.type,
+      context: parsed.data.context,
+      outcome
+    }
+  });
+
+  res.json({ policy: policy.id, outcome });
+});
+
+export default router;

--- a/apps/api/src/routes/invoices.ts
+++ b/apps/api/src/routes/invoices.ts
@@ -1,0 +1,120 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { Prisma, RelationshipType, Role } from '@prisma/client';
+import PDFDocument from 'pdfkit';
+import { requireAuth, requireRole, AuthenticatedRequest } from '../middleware/auth';
+import { prisma } from '../prisma';
+import { AppError } from '../utils/errors';
+import { recordAudit } from '../services/audit';
+import { monthBounds } from '../utils/dates';
+
+const router = Router();
+
+const issueSchema = z.object({
+  period: z.string().regex(/^\d{4}-\d{2}$/),
+  parentId: z.string().cuid()
+});
+
+router.post('/issue', requireAuth, requireRole([Role.Tutor]), async (req: AuthenticatedRequest, res) => {
+  const parsed = issueSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid invoice payload', parsed.error.flatten());
+  }
+
+  const { period, parentId } = parsed.data;
+  const { start, end } = monthBounds(period);
+
+  const studentLinks = await prisma.relationship.findMany({
+    where: { bUserId: parentId, type: RelationshipType.S_P, consent: true }
+  });
+
+  const lineItems: Array<{ type: string; qty: number; unitPrice: number }> = [];
+
+  for (const link of studentLinks) {
+    const attendance = await prisma.attendanceLog.findMany({
+      where: { studentId: link.aUserId, sessionDate: { gte: start, lt: end } }
+    });
+    const minutes = attendance.reduce((sum, log) => sum + log.minutes, 0);
+    if (minutes > 0) {
+      lineItems.push({ type: 'tuition', qty: minutes, unitPrice: 1.2 });
+    }
+  }
+
+  if (lineItems.length === 0) {
+    lineItems.push({ type: 'materials', qty: 1, unitPrice: 10 });
+  }
+
+  const total = lineItems.reduce((sum, item) => sum + item.qty * item.unitPrice, 0);
+
+  const invoice = await prisma.invoice.create({
+    data: {
+      period,
+      parentId,
+      lineItems,
+      total: new Prisma.Decimal(total.toFixed(2)),
+      status: 'Issued',
+      issuedAt: new Date()
+    }
+  });
+
+  await recordAudit({
+    actorId: req.user!.id,
+    entity: 'Invoice',
+    entityId: invoice.id,
+    action: 'INVOICE_ISSUED',
+    metadata: { lineItemCount: lineItems.length }
+  });
+
+  res.status(201).json({ invoice });
+});
+
+router.get('/:id', requireAuth, requireRole([Role.Parent, Role.Tutor]), async (req: AuthenticatedRequest, res) => {
+  const invoice = await prisma.invoice.findUnique({ where: { id: req.params.id } });
+  if (!invoice) {
+    throw new AppError(404, 'Invoice not found');
+  }
+
+  if (req.user!.role === Role.Parent && invoice.parentId !== req.user!.id) {
+    throw new AppError(403, 'Forbidden');
+  }
+
+  res.json({ invoice });
+});
+
+router.get('/:id/receipt', requireAuth, requireRole([Role.Parent, Role.Tutor]), async (req: AuthenticatedRequest, res) => {
+  const invoice = await prisma.invoice.findUnique({ where: { id: req.params.id } });
+  if (!invoice) {
+    throw new AppError(404, 'Invoice not found');
+  }
+
+  if (req.user!.role === Role.Parent && invoice.parentId !== req.user!.id) {
+    throw new AppError(403, 'Forbidden');
+  }
+
+  const doc = new PDFDocument();
+  const buffers: Buffer[] = [];
+  doc.on('data', (chunk) => buffers.push(chunk as Buffer));
+  doc.on('end', () => {
+    const pdf = Buffer.concat(buffers);
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Length', pdf.length.toString());
+    res.send(pdf);
+  });
+
+  doc.fontSize(18).text('Invoice Receipt', { underline: true });
+  doc.moveDown();
+  doc.fontSize(12).text(`Invoice ID: ${invoice.id}`);
+  doc.text(`Period: ${invoice.period}`);
+  doc.text(`Total: $${invoice.total.toString()}`);
+  doc.text(`Status: ${invoice.status}`);
+  doc.moveDown();
+  doc.text('Line Items:');
+  const items = invoice.lineItems as Array<{ type: string; qty: number; unitPrice: number }>;
+  items.forEach((item) => {
+    doc.text(`- ${item.type} x${item.qty} @ $${item.unitPrice}`);
+  });
+
+  doc.end();
+});
+
+export default router;

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,0 +1,75 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { AssignmentStatus, Role } from '@prisma/client';
+import { requireAuth, requireRole, AuthenticatedRequest } from '../middleware/auth';
+import { ensureTutorForStudent } from '../services/access';
+import { prisma } from '../prisma';
+import { AppError } from '../utils/errors';
+import { recordAudit } from '../services/audit';
+import { monthBounds } from '../utils/dates';
+
+const router = Router();
+
+const issueSchema = z.object({
+  period: z.string().regex(/^\d{4}-\d{2}$/),
+  studentId: z.string().cuid()
+});
+
+router.post('/issue', requireAuth, requireRole([Role.Tutor]), async (req: AuthenticatedRequest, res) => {
+  const parsed = issueSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid report payload', parsed.error.flatten());
+  }
+
+  const { period, studentId } = parsed.data;
+  await ensureTutorForStudent(req.user!.id, studentId);
+
+  const { start, end } = monthBounds(period);
+
+  const finalizedAssignments = await prisma.assignment.count({
+    where: { studentId, status: AssignmentStatus.Finalized, createdAt: { gte: start, lt: end } }
+  });
+
+  const attendanceLogs = await prisma.attendanceLog.findMany({
+    where: { studentId, sessionDate: { gte: start, lt: end } }
+  });
+  const attendanceMinutes = attendanceLogs.reduce((sum, log) => sum + log.minutes, 0);
+
+  const latestSubmission = await prisma.submission.findFirst({
+    where: { studentId },
+    orderBy: { createdAt: 'desc' }
+  });
+
+  const latestNote = await prisma.sessionNote.findFirst({
+    where: { studentId },
+    orderBy: { date: 'desc' }
+  });
+
+  const report = await prisma.report.create({
+    data: {
+      period,
+      studentId,
+      KPIs: {
+        assignmentsFinalized: finalizedAssignments,
+        attendanceMinutes,
+        submissionsThisMonth: latestSubmission ? 1 : 0
+      },
+      highlights: [
+        latestSubmission ? { submission: latestSubmission.id, title: latestSubmission.assignmentId } : null,
+        latestNote ? { note: latestNote.id, summary: latestNote.summary } : null
+      ].filter(Boolean),
+      nextPlan: latestNote?.nextActions ?? []
+    }
+  });
+
+  await recordAudit({
+    actorId: req.user!.id,
+    entity: 'Report',
+    entityId: report.id,
+    action: 'REPORT_ISSUED'
+  });
+
+  res.status(201).json({ report });
+});
+
+export default router;

--- a/apps/api/src/routes/session-notes.ts
+++ b/apps/api/src/routes/session-notes.ts
@@ -1,0 +1,73 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { Role } from '@prisma/client';
+import { requireAuth, requireRole, AuthenticatedRequest } from '../middleware/auth';
+import { ensureTutorForStudent } from '../services/access';
+import { prisma } from '../prisma';
+import { AppError } from '../utils/errors';
+import { recordAudit } from '../services/audit';
+
+const router = Router();
+
+const noteSchema = z.object({
+  studentId: z.string().cuid(),
+  date: z.string(),
+  summary: z.string().min(1),
+  issues: z.array(z.unknown()).default([]),
+  nextActions: z.array(z.unknown()).default([]),
+  visibilityScope: z.enum(['S', 'SP', 'ST', 'SPT'])
+});
+
+router.post('/', requireAuth, requireRole([Role.Tutor]), async (req: AuthenticatedRequest, res) => {
+  const parsed = noteSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid session note payload', parsed.error.flatten());
+  }
+
+  const tutorId = req.user!.id;
+  const { studentId, date, summary, issues, nextActions, visibilityScope } = parsed.data;
+  await ensureTutorForStudent(tutorId, studentId);
+
+  const sessionDate = new Date(date);
+  if (Number.isNaN(sessionDate.getTime())) {
+    throw new AppError(400, 'Invalid date');
+  }
+
+  const latestAttendance = await prisma.attendanceLog.findFirst({
+    where: { tutorId, studentId },
+    orderBy: { endTs: 'desc' }
+  });
+
+  const now = new Date();
+  let warning: string | undefined;
+  if (latestAttendance) {
+    const diff = Math.abs(now.getTime() - latestAttendance.endTs.getTime());
+    if (diff > 60 * 1000) {
+      warning = 'Session note created outside 60s window';
+    }
+  }
+
+  const note = await prisma.sessionNote.create({
+    data: {
+      tutorId,
+      studentId,
+      date: sessionDate,
+      summary,
+      issues,
+      nextActions,
+      visibilityScope
+    }
+  });
+
+  await recordAudit({
+    actorId: tutorId,
+    entity: 'SessionNote',
+    entityId: note.id,
+    action: 'SESSION_NOTE_RECORDED',
+    metadata: { warning: warning ?? null }
+  });
+
+  res.status(201).json({ note, warning: warning ?? null });
+});
+
+export default router;

--- a/apps/api/src/routes/sla.ts
+++ b/apps/api/src/routes/sla.ts
@@ -1,0 +1,37 @@
+import { Router } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth';
+import { ensureStudentVisibility } from '../services/access';
+import { prisma } from '../prisma';
+
+const router = Router();
+
+router.get('/feedback/:studentId', requireAuth, async (req: AuthenticatedRequest, res) => {
+  const { studentId } = req.params;
+  await ensureStudentVisibility(req.user!.id, req.user!.role, studentId);
+
+  const submission = await prisma.submission.findFirst({
+    where: { studentId },
+    orderBy: { createdAt: 'desc' }
+  });
+
+  if (!submission) {
+    res.json({ status: 'done', etaWindow: null });
+    return;
+  }
+
+  if (submission.status === 'Submitted') {
+    const etaEnd = new Date(submission.createdAt.getTime() + 24 * 60 * 60 * 1000);
+    res.json({ status: 'waiting', etaWindow: { start: submission.createdAt.toISOString(), end: etaEnd.toISOString() } });
+    return;
+  }
+
+  if (submission.status === 'NeedsResubmit') {
+    const etaEnd = new Date(submission.createdAt.getTime() + 48 * 60 * 60 * 1000);
+    res.json({ status: 'in_progress', etaWindow: { start: submission.createdAt.toISOString(), end: etaEnd.toISOString() } });
+    return;
+  }
+
+  res.json({ status: 'done', etaWindow: null });
+});
+
+export default router;

--- a/apps/api/src/routes/submissions.ts
+++ b/apps/api/src/routes/submissions.ts
@@ -1,0 +1,211 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { AssignmentStatus, Role, SubmissionStatus } from '@prisma/client';
+import { requireAuth, requireRole, AuthenticatedRequest } from '../middleware/auth';
+import { prisma } from '../prisma';
+import { AppError } from '../utils/errors';
+import { ensureTutorForStudent } from '../services/access';
+import { recordAudit } from '../services/audit';
+import { setAssignmentStatus } from '../services/assignments';
+
+const router = Router();
+
+const ALLOWED_MIME = ['application/pdf', 'text/plain', 'image/png', 'image/jpeg'];
+
+type SubmissionFile = { name: string; mime: string; url: string };
+
+const submissionSchema = z.object({
+  assignmentId: z.string().cuid(),
+  files: z.array(
+    z.object({
+      name: z.string().min(1),
+      mime: z.string().min(1),
+      url: z.string().url()
+    })
+  ),
+  coverMeta: z.object({ unit: z.string().min(1), pages: z.number().int().positive().optional() })
+});
+
+router.post('/', requireAuth, requireRole([Role.Student]), async (req: AuthenticatedRequest, res) => {
+  const parsed = submissionSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid submission payload', parsed.error.flatten());
+  }
+
+  const { assignmentId, files, coverMeta } = parsed.data;
+  const assignment = await prisma.assignment.findUnique({ where: { id: assignmentId }, include: { submissions: true } });
+  if (!assignment) {
+    throw new AppError(404, 'Assignment not found');
+  }
+
+  if (assignment.studentId !== req.user!.id) {
+    throw new AppError(403, 'Cannot submit for other students');
+  }
+
+  const invalid = files.find((file) => !ALLOWED_MIME.includes(file.mime));
+  if (invalid) {
+    throw new AppError(400, `Unsupported file type ${invalid.mime}`);
+  }
+
+  const version = assignment.submissions.length + 1;
+
+  const submission = await prisma.submission.create({
+    data: {
+      assignmentId,
+      studentId: req.user!.id,
+      version,
+      files,
+      coverMeta,
+      status: SubmissionStatus.Submitted
+    }
+  });
+
+  await setAssignmentStatus(assignmentId, AssignmentStatus.Submitted, req.user!.id);
+  await recordAudit({
+    actorId: req.user!.id,
+    entity: 'Submission',
+    entityId: submission.id,
+    action: 'SUBMISSION_CREATED',
+    toState: SubmissionStatus.Submitted
+  });
+
+  res.status(201).json({ submission });
+});
+
+const reviewSchema = z.object({
+  rubricScore: z.record(z.unknown()),
+  comment: z.string().optional(),
+  resubmit_flag: z.boolean()
+});
+
+const resubmitSchema = z
+  .object({
+    files: submissionSchema.shape.files.optional(),
+    coverMeta: submissionSchema.shape.coverMeta.optional()
+  })
+  .refine((data) => data.files !== undefined || data.coverMeta !== undefined, {
+    message: 'files or coverMeta required'
+  });
+
+router.post('/:id/review', requireAuth, requireRole([Role.Tutor]), async (req: AuthenticatedRequest, res) => {
+  const parsed = reviewSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid review payload', parsed.error.flatten());
+  }
+
+  const submission = await prisma.submission.findUnique({
+    where: { id: req.params.id },
+    include: { assignment: true }
+  });
+  if (!submission) {
+    throw new AppError(404, 'Submission not found');
+  }
+
+  await ensureTutorForStudent(req.user!.id, submission.assignment.studentId);
+
+  const status = parsed.data.resubmit_flag ? SubmissionStatus.NeedsResubmit : SubmissionStatus.Approved;
+  const now = new Date();
+  const reviewDurationSeconds = Math.max(0, Math.round((now.getTime() - submission.createdAt.getTime()) / 1000));
+
+  const updated = await prisma.submission.update({
+    where: { id: submission.id },
+    data: {
+      status,
+      rubricScore: parsed.data.rubricScore,
+      comment: parsed.data.comment,
+      requestedResubmit: parsed.data.resubmit_flag,
+      reviewedAt: now,
+      reviewDurationSeconds
+    }
+  });
+
+  if (parsed.data.resubmit_flag) {
+    await setAssignmentStatus(submission.assignmentId, AssignmentStatus.Reviewed, req.user!.id);
+  } else {
+    const targetStatus = submission.version > 1 || submission.assignment.status === AssignmentStatus.Resubmitted ? AssignmentStatus.Finalized : AssignmentStatus.Reviewed;
+    await setAssignmentStatus(submission.assignmentId, targetStatus, req.user!.id);
+  }
+
+  await recordAudit({
+    actorId: req.user!.id,
+    entity: 'Submission',
+    entityId: submission.id,
+    action: 'SUBMISSION_REVIEWED',
+    fromState: submission.status,
+    toState: status,
+    metadata: { resubmit: parsed.data.resubmit_flag }
+  });
+
+  const slaSeconds = reviewDurationSeconds;
+  res.json({ submission: updated, slaSeconds });
+});
+
+router.post('/:id/resubmit', requireAuth, requireRole([Role.Student]), async (req: AuthenticatedRequest, res) => {
+  const original = await prisma.submission.findUnique({
+    where: { id: req.params.id },
+    include: { assignment: { include: { submissions: true } } }
+  });
+  if (!original) {
+    throw new AppError(404, 'Submission not found');
+  }
+
+  if (original.studentId !== req.user!.id) {
+    throw new AppError(403, 'Cannot resubmit others work');
+  }
+
+  if (original.status !== SubmissionStatus.NeedsResubmit) {
+    throw new AppError(400, 'Submission not flagged for resubmission');
+  }
+
+  const parsed = resubmitSchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid resubmission payload', parsed.error.flatten());
+  }
+
+  const latestVersion = original.assignment.submissions.length;
+
+  const fallbackFiles = Array.isArray(original.files) ? (original.files as SubmissionFile[]) : [];
+  const files: SubmissionFile[] = parsed.data.files ?? fallbackFiles;
+
+  if (files.length === 0) {
+    throw new AppError(400, 'Resubmission requires at least one file');
+  }
+
+  const invalid = files.find((file) => !ALLOWED_MIME.includes(file.mime));
+  if (invalid) {
+    throw new AppError(400, `Unsupported file type ${invalid.mime}`);
+  }
+
+  const fallbackCoverMeta =
+    typeof original.coverMeta === 'object' && original.coverMeta !== null ? original.coverMeta : null;
+  const coverMeta = parsed.data.coverMeta ?? fallbackCoverMeta;
+
+  if (!coverMeta) {
+    throw new AppError(400, 'Resubmission requires cover metadata');
+  }
+
+  const newSubmission = await prisma.submission.create({
+    data: {
+      assignmentId: original.assignmentId,
+      studentId: req.user!.id,
+      version: latestVersion + 1,
+      files,
+      coverMeta,
+      status: SubmissionStatus.Submitted
+    }
+  });
+
+  await setAssignmentStatus(original.assignmentId, AssignmentStatus.Resubmitted, req.user!.id);
+  await recordAudit({
+    actorId: req.user!.id,
+    entity: 'Submission',
+    entityId: newSubmission.id,
+    action: 'SUBMISSION_RESUBMITTED',
+    fromState: original.status,
+    toState: SubmissionStatus.Submitted
+  });
+
+  res.status(201).json({ submission: newSubmission });
+});
+
+export default router;

--- a/apps/api/src/routes/visibility.ts
+++ b/apps/api/src/routes/visibility.ts
@@ -1,0 +1,39 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { Role, SessionVisibility } from '@prisma/client';
+import { requireAuth, requireRole, AuthenticatedRequest } from '../middleware/auth';
+import { prisma } from '../prisma';
+import { AppError } from '../utils/errors';
+import { recordAudit } from '../services/audit';
+
+const router = Router();
+
+const visibilitySchema = z.object({
+  entityRef: z.string().min(3),
+  scope: z.enum(['S', 'SP', 'ST', 'SPT'])
+});
+
+router.post('/', requireAuth, requireRole([Role.Tutor, Role.Parent]), async (req: AuthenticatedRequest, res) => {
+  const parsed = visibilitySchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError(400, 'Invalid visibility payload', parsed.error.flatten());
+  }
+
+  const record = await prisma.visibilitySetting.upsert({
+    where: { entityRef: parsed.data.entityRef },
+    update: { scope: parsed.data.scope as SessionVisibility },
+    create: { entityRef: parsed.data.entityRef, scope: parsed.data.scope as SessionVisibility }
+  });
+
+  await recordAudit({
+    actorId: req.user!.id,
+    entity: 'Visibility',
+    entityId: record.id,
+    action: 'VISIBILITY_UPDATED',
+    metadata: { entityRef: parsed.data.entityRef, scope: parsed.data.scope }
+  });
+
+  res.json({ visibility: record });
+});
+
+export default router;

--- a/apps/api/src/services/access.ts
+++ b/apps/api/src/services/access.ts
@@ -1,0 +1,61 @@
+import { prisma } from '../prisma';
+import { AppError } from '../utils/errors';
+import { Role, RelationshipType } from '@prisma/client';
+
+export async function ensureTutorForStudent(tutorId: string, studentId: string): Promise<void> {
+  const relation = await prisma.relationship.findFirst({
+    where: {
+      type: RelationshipType.S_T,
+      aUserId: studentId,
+      bUserId: tutorId,
+      consent: true
+    }
+  });
+  if (!relation) {
+    throw new AppError(403, 'Tutor not linked to student');
+  }
+}
+
+export async function ensureParentForStudent(parentId: string, studentId: string): Promise<void> {
+  const relation = await prisma.relationship.findFirst({
+    where: {
+      type: RelationshipType.S_P,
+      aUserId: studentId,
+      bUserId: parentId,
+      consent: true
+    }
+  });
+  if (!relation) {
+    throw new AppError(403, 'Parent not linked to student');
+  }
+}
+
+export async function ensureParticipant(userId: string, eventId: string): Promise<void> {
+  const event = await prisma.calendarEvent.findUnique({ where: { id: eventId } });
+  if (!event) {
+    throw new AppError(404, 'Event not found');
+  }
+
+  const participants = Array.isArray(event.participants) ? (event.participants as string[]) : [];
+  if (!participants.includes(userId)) {
+    throw new AppError(403, 'Not a participant');
+  }
+}
+
+export async function ensureStudentVisibility(userId: string, role: Role, studentId: string): Promise<void> {
+  if (role === Role.Student) {
+    if (userId !== studentId) {
+      throw new AppError(403, 'Cannot access other students');
+    }
+    return;
+  }
+
+  if (role === Role.Tutor) {
+    await ensureTutorForStudent(userId, studentId);
+    return;
+  }
+
+  if (role === Role.Parent) {
+    await ensureParentForStudent(userId, studentId);
+  }
+}

--- a/apps/api/src/services/assignments.ts
+++ b/apps/api/src/services/assignments.ts
@@ -1,0 +1,20 @@
+import { AssignmentStatus } from '@prisma/client';
+import { prisma } from '../prisma';
+import { recordAudit } from './audit';
+
+export async function setAssignmentStatus(assignmentId: string, to: AssignmentStatus, actorId: string): Promise<void> {
+  const current = await prisma.assignment.findUnique({ where: { id: assignmentId } });
+  if (!current || current.status === to) {
+    return;
+  }
+
+  await prisma.assignment.update({ where: { id: assignmentId }, data: { status: to } });
+  await recordAudit({
+    actorId,
+    entity: 'Assignment',
+    entityId: assignmentId,
+    action: 'ASSIGNMENT_STATUS_CHANGED',
+    fromState: current.status,
+    toState: to
+  });
+}

--- a/apps/api/src/services/audit.ts
+++ b/apps/api/src/services/audit.ts
@@ -1,0 +1,26 @@
+import { AuditLog } from '@prisma/client';
+import { prisma } from '../prisma';
+
+export interface AuditInput {
+  actorId?: string;
+  entity: string;
+  entityId: string;
+  action: string;
+  fromState?: string | null;
+  toState?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export async function recordAudit(input: AuditInput): Promise<AuditLog> {
+  return prisma.auditLog.create({
+    data: {
+      actorId: input.actorId,
+      entity: input.entity,
+      entityId: input.entityId,
+      action: input.action,
+      fromState: input.fromState ?? undefined,
+      toState: input.toState ?? undefined,
+      metadata: input.metadata ?? undefined
+    }
+  });
+}

--- a/apps/api/src/services/visibility.ts
+++ b/apps/api/src/services/visibility.ts
@@ -1,0 +1,22 @@
+import { Role, SessionVisibility } from '@prisma/client';
+import { prisma } from '../prisma';
+
+export function scopeAllows(scope: SessionVisibility, role: Role): boolean {
+  switch (role) {
+    case Role.Student:
+      return scope === SessionVisibility.S || scope === SessionVisibility.SP || scope === SessionVisibility.ST || scope === SessionVisibility.SPT;
+    case Role.Parent:
+      return scope === SessionVisibility.SP || scope === SessionVisibility.SPT;
+    case Role.Tutor:
+      return scope === SessionVisibility.ST || scope === SessionVisibility.SPT;
+    default:
+      return false;
+  }
+}
+
+const DEFAULT_SCOPE = SessionVisibility.SPT;
+
+export async function getVisibility(entityRef: string): Promise<SessionVisibility> {
+  const record = await prisma.visibilitySetting.findUnique({ where: { entityRef } });
+  return record?.scope ?? DEFAULT_SCOPE;
+}

--- a/apps/api/src/utils/dates.ts
+++ b/apps/api/src/utils/dates.ts
@@ -1,0 +1,9 @@
+export function monthBounds(period: string): { start: Date; end: Date } {
+  const [year, month] = period.split('-').map((part) => Number.parseInt(part, 10));
+  if (!year || !month || month < 1 || month > 12) {
+    throw new Error('Invalid period');
+  }
+  const start = new Date(Date.UTC(year, month - 1, 1));
+  const end = new Date(Date.UTC(year, month, 1));
+  return { start, end };
+}

--- a/apps/api/src/utils/errors.ts
+++ b/apps/api/src/utils/errors.ts
@@ -1,0 +1,10 @@
+export class AppError extends Error {
+  status: number;
+  details?: unknown;
+
+  constructor(status: number, message: string, details?: unknown) {
+    super(message);
+    this.status = status;
+    this.details = details;
+  }
+}

--- a/apps/api/tests/core.spec.ts
+++ b/apps/api/tests/core.spec.ts
@@ -1,0 +1,243 @@
+import request from 'supertest';
+import { createApp } from '../src/app';
+import { prisma } from '../src/prisma';
+
+const app = createApp();
+
+describe('End-to-end MVP loops', () => {
+  let tutorToken: string;
+  let parentToken: string;
+  let studentToken: string;
+  let tutorId: string;
+  let parentId: string;
+  let studentId: string;
+  let assignmentId: string;
+  let firstSubmissionId: string;
+  let resubmissionId: string;
+  let attendanceId: string;
+  let invoiceId: string;
+
+  beforeAll(async () => {
+    const tutorLogin = await request(app).post('/auth/login').send({ email: 'tutor@example.com', password: 'password123' });
+    tutorToken = tutorLogin.body.token;
+    tutorId = tutorLogin.body.user.id;
+
+    const parentLogin = await request(app).post('/auth/login').send({ email: 'parent@example.com', password: 'password123' });
+    parentToken = parentLogin.body.token;
+    parentId = parentLogin.body.user.id;
+
+    const studentLogin = await request(app).post('/auth/login').send({ email: 'student@example.com', password: 'password123' });
+    studentToken = studentLogin.body.token;
+    studentId = studentLogin.body.user.id;
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('runs assignment submission and review loop to finalization', async () => {
+    const createRes = await request(app)
+      .post('/assignments')
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({
+        studentId,
+        title: 'Weekly Writing',
+        goal: 'Compose persuasive essay',
+        difficulty: 'M',
+        dueAt: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+        rubricId: 'rubric-2',
+        modelAnswerRef: 's3://answers/model2.pdf'
+      })
+      .expect(201);
+
+    assignmentId = createRes.body.assignment.id;
+
+    const submissionRes = await request(app)
+      .post('/submissions')
+      .set('Authorization', `Bearer ${studentToken}`)
+      .send({
+        assignmentId,
+        files: [{ name: 'draft.pdf', mime: 'application/pdf', url: 'https://example.com/draft.pdf' }],
+        coverMeta: { unit: 'Writing', pages: 3 }
+      })
+      .expect(201);
+
+    firstSubmissionId = submissionRes.body.submission.id;
+
+    const slaWaiting = await request(app)
+      .get(`/sla/feedback/${studentId}`)
+      .set('Authorization', `Bearer ${studentToken}`)
+      .expect(200);
+    expect(slaWaiting.body.status).toBe('waiting');
+
+    await request(app)
+      .post(`/submissions/${firstSubmissionId}/review`)
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({ rubricScore: { writing: 2 }, comment: 'Revise thesis', resubmit_flag: true })
+      .expect(200);
+
+    const slaInProgress = await request(app)
+      .get(`/sla/feedback/${studentId}`)
+      .set('Authorization', `Bearer ${studentToken}`)
+      .expect(200);
+    expect(slaInProgress.body.status).toBe('in_progress');
+
+    const resubmitRes = await request(app)
+      .post(`/submissions/${firstSubmissionId}/resubmit`)
+      .set('Authorization', `Bearer ${studentToken}`)
+      .send({
+        files: [
+          {
+            name: 'draft-v2.pdf',
+            mime: 'application/pdf',
+            url: 'https://example.com/draft-v2.pdf'
+          }
+        ],
+        coverMeta: { unit: 'Writing', pages: 4 }
+      })
+      .expect(201);
+    resubmissionId = resubmitRes.body.submission.id;
+
+    await request(app)
+      .post(`/submissions/${resubmissionId}/review`)
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({ rubricScore: { writing: 4 }, comment: 'Great job', resubmit_flag: false })
+      .expect(200);
+
+    const assignmentsForTutor = await request(app)
+      .get(`/assignments/students/${studentId}`)
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .expect(200);
+
+    const targetAssignment = assignmentsForTutor.body.assignments.find((entry: any) => entry.assignment.id === assignmentId);
+    expect(targetAssignment.assignment.status).toBe('Finalized');
+
+    const slaDone = await request(app)
+      .get(`/sla/feedback/${studentId}`)
+      .set('Authorization', `Bearer ${studentToken}`)
+      .expect(200);
+    expect(slaDone.body.status).toBe('done');
+  });
+
+  it('handles scheduling, attendance logging, signatures, and session note guard', async () => {
+    const now = Date.now();
+    const proposals = await request(app)
+      .post('/calendar/proposals')
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({
+        studentId,
+        options: [1, 2, 3].map((offset) => ({
+          start: new Date(now + offset * 60 * 60 * 1000).toISOString(),
+          end: new Date(now + offset * 60 * 60 * 1000 + 45 * 60 * 1000).toISOString()
+        }))
+      })
+      .expect(201);
+
+    const eventId = proposals.body.events[0].id;
+
+    await request(app)
+      .post('/calendar/confirm')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ eventId })
+      .expect(200);
+
+    const attendanceRes = await request(app)
+      .post(`/attendance/${eventId}/log`)
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({
+        studentId,
+        tutorId,
+        startTs: new Date(Date.now() - 45 * 60 * 1000).toISOString(),
+        endTs: new Date().toISOString(),
+        minutes: 45
+      })
+      .expect(201);
+
+    attendanceId = attendanceRes.body.attendance.id;
+
+    await request(app)
+      .post(`/attendance/${attendanceId}/sign`)
+      .set('Authorization', `Bearer ${parentToken}`)
+      .expect(200);
+
+    await request(app)
+      .post('/session-notes')
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({
+        studentId,
+        date: new Date().toISOString(),
+        summary: 'Followed up on persuasive techniques',
+        issues: ['Focus'],
+        nextActions: ['Mock debate'],
+        visibilityScope: 'SPT'
+      })
+      .expect(201);
+  });
+
+  it('issues monthly reports and invoices and serves PDF receipts', async () => {
+    const period = new Date().toISOString().slice(0, 7);
+
+    await request(app)
+      .post('/reports/issue')
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({ period, studentId })
+      .expect(201);
+
+    const invoiceRes = await request(app)
+      .post('/invoices/issue')
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({ period, parentId })
+      .expect(201);
+
+    invoiceId = invoiceRes.body.invoice.id;
+
+    await request(app)
+      .get(`/invoices/${invoiceId}`)
+      .set('Authorization', `Bearer ${parentToken}`)
+      .expect(200);
+
+    const receiptRes = await request(app)
+      .get(`/invoices/${invoiceId}/receipt`)
+      .set('Authorization', `Bearer ${parentToken}`)
+      .expect(200);
+    expect(receiptRes.headers['content-type']).toContain('application/pdf');
+  });
+
+  it('generates daily digest, encouragement notifications, visibility controls, and policy exceptions', async () => {
+    const digestRes = await request(app)
+      .get('/daily-digest')
+      .query({ relationship: 'S-P', studentId })
+      .set('Authorization', `Bearer ${parentToken}`)
+      .expect(200);
+    expect(digestRes.body.highlights).toBeDefined();
+
+    await request(app)
+      .post('/encourage')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ studentId, message: 'Proud of your progress!' })
+      .expect(201);
+
+    const notifications = await prisma.notification.findMany({ where: { recipientId: studentId } });
+    expect(notifications.length).toBeGreaterThan(0);
+
+    await request(app)
+      .post('/visibility')
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({ entityRef: `assignment:${assignmentId}`, scope: 'S' })
+      .expect(200);
+
+    const parentAssignments = await request(app)
+      .get(`/assignments/students/${studentId}`)
+      .set('Authorization', `Bearer ${parentToken}`)
+      .expect(200);
+    const visibleAssignments = parentAssignments.body.assignments.filter((entry: any) => entry.assignment.id === assignmentId);
+    expect(visibleAssignments.length).toBe(0);
+
+    const exceptionRes = await request(app)
+      .post('/exceptions/apply')
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({ type: 'absence', context: { noticeHours: 2 } })
+      .expect(200);
+    expect(exceptionRes.body.outcome).toBeDefined();
+  });
+});

--- a/apps/api/tests/setup.ts
+++ b/apps/api/tests/setup.ts
@@ -1,0 +1,26 @@
+import { execSync } from 'child_process';
+import path from 'path';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+
+const defaultDbUrl = 'postgresql://start:start@localhost:5432/start?schema=public';
+
+export default async function globalSetup(): Promise<void> {
+  if (!process.env.DATABASE_URL) {
+    process.env.DATABASE_URL = defaultDbUrl;
+  }
+
+  const cwd = path.resolve(__dirname, '..');
+  execSync('npx prisma migrate deploy', {
+    cwd,
+    env: { ...process.env },
+    stdio: 'inherit'
+  });
+
+  execSync('npx prisma db seed', {
+    cwd,
+    env: { ...process.env },
+    stdio: 'inherit'
+  });
+}

--- a/apps/api/tests/teardown.ts
+++ b/apps/api/tests/teardown.ts
@@ -1,0 +1,7 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export default async function globalTeardown(): Promise<void> {
+  await prisma.$disconnect();
+}

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "sourceMap": false
+  },
+  "exclude": ["tests", "**/*.spec.ts"]
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/apps/web/app/(parent)/error.tsx
+++ b/apps/web/app/(parent)/error.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+export default function ParentError({ error }: { error: Error }) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-2 bg-slate-50 text-slate-600">
+      <h1 className="text-lg font-semibold text-red-600">부모 요약을 불러오지 못했습니다.</h1>
+      <p className="text-sm">{error.message}</p>
+    </main>
+  );
+}

--- a/apps/web/app/(parent)/loading.tsx
+++ b/apps/web/app/(parent)/loading.tsx
@@ -1,0 +1,7 @@
+export default function ParentLoading() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-slate-50 text-slate-500">
+      <p role="status">부모 요약을 준비하는 중…</p>
+    </main>
+  );
+}

--- a/apps/web/app/(parent)/page.tsx
+++ b/apps/web/app/(parent)/page.tsx
@@ -1,0 +1,60 @@
+import { DecisionCard } from '@/components/DecisionCard';
+import { getParentDashboard } from '@/lib/api';
+
+export default async function ParentHome() {
+  const data = await getParentDashboard();
+  const digest = data.digest;
+  const dueSoon = Array.isArray(digest?.risks?.due_in_48h_without_submission)
+    ? (digest?.risks?.due_in_48h_without_submission as Array<Record<string, unknown>>)[0]
+    : null;
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col gap-6 px-6 py-8">
+      <header className="rounded-lg bg-accent/10 p-6">
+        <h1 className="text-2xl font-semibold text-accent">하루 1분 요약</h1>
+        <p className="mt-1 text-sm text-accent/80">마감과 출결 리스크를 한눈에 보고 바로 조치하세요.</p>
+      </header>
+
+      <section className="space-y-4">
+        <DecisionCard
+          title={dueSoon ? `마감 임박: ${dueSoon.title ?? '과제'}` : '마감 임박 과제 없음'}
+          description={dueSoon ? `제출 마감일: ${dueSoon.dueAt ?? '알수없음'}` : '현재 48시간 내 마감 예정 과제가 없습니다.'}
+          actionLabel={dueSoon ? '학생 독려하기' : '좋아요'}
+          href="/student"
+        />
+        <DecisionCard
+          title="서명 요청"
+          description="출결/결제 승인 대기 항목을 바로 처리합니다."
+          actionLabel="1-click 서명"
+          href="/invoices/pending"
+        />
+        <DecisionCard
+          title="격려 보내기"
+          description="맞춤 메시지로 학생 동기 부여."
+          actionLabel="격려 작성"
+          href="/encourage"
+          variant="secondary"
+        />
+      </section>
+
+      {digest ? (
+        <section className="rounded-lg bg-white p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-slate-900">요약</h2>
+          <div className="mt-3 space-y-2 text-sm text-slate-600">
+            <p>
+              <strong>하이라이트:</strong> {JSON.stringify(digest.highlights)}
+            </p>
+            <p>
+              <strong>리스크:</strong> {JSON.stringify(digest.risks)}
+            </p>
+            <p>
+              <strong>Next:</strong> {JSON.stringify(digest.next)}
+            </p>
+          </div>
+        </section>
+      ) : null}
+
+      {data.message ? <p className="text-sm text-amber-600">{data.message}</p> : null}
+    </main>
+  );
+}

--- a/apps/web/app/(student)/error.tsx
+++ b/apps/web/app/(student)/error.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+export default function StudentError({ error }: { error: Error }) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-2 bg-slate-50 text-slate-600">
+      <h1 className="text-lg font-semibold text-red-600">학생 화면을 불러오지 못했습니다.</h1>
+      <p className="text-sm">{error.message}</p>
+    </main>
+  );
+}

--- a/apps/web/app/(student)/loading.tsx
+++ b/apps/web/app/(student)/loading.tsx
@@ -1,0 +1,7 @@
+export default function StudentLoading() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-slate-50 text-slate-500">
+      <p role="status">학생 데이터를 불러오는 중…</p>
+    </main>
+  );
+}

--- a/apps/web/app/(student)/page.tsx
+++ b/apps/web/app/(student)/page.tsx
@@ -1,0 +1,45 @@
+import { DecisionCard } from '@/components/DecisionCard';
+import { StatPanel } from '@/components/StatPanel';
+import { getStudentDashboard } from '@/lib/api';
+import { formatDistanceToNow } from 'date-fns';
+
+export default async function StudentHome() {
+  const data = await getStudentDashboard();
+  const nextAssignment = data.pendingAssignments[0];
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col gap-6 px-6 py-8">
+      <header className="rounded-lg bg-primary/10 p-6">
+        <h1 className="text-2xl font-semibold text-primary">오늘 할 일</h1>
+        <p className="mt-1 text-sm text-primary/80">제출 마감까지 남은 시간을 확인하고 한 번에 업로드하세요.</p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <StatPanel
+          label="D-Day"
+          value={
+            nextAssignment
+              ? `${formatDistanceToNow(new Date(nextAssignment.dueAt), { addSuffix: true })}`
+              : '다음 과제가 없습니다'
+          }
+        />
+        <StatPanel label="격려 받음" value={data.latestEncouragement ?? '연결 시 최신 메시지가 표시됩니다.'} />
+      </section>
+
+      <DecisionCard
+        title={nextAssignment ? nextAssignment.title : '과제가 없습니다'}
+        description={nextAssignment ? '파일을 업로드하면 튜터에게 바로 전달됩니다.' : '튜터가 새 과제를 만들면 여기에 표시됩니다.'}
+        actionLabel={nextAssignment ? '지금 제출하기' : '새로 고침'}
+        href={nextAssignment ? `/assignments/${nextAssignment.id}` : undefined}
+        onClick={nextAssignment ? undefined : async () => undefined}
+        disabled={!nextAssignment}
+      />
+
+      {data.message ? (
+        <p className="text-sm text-amber-600" role="status">
+          {data.message}
+        </p>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/web/app/(tutor)/error.tsx
+++ b/apps/web/app/(tutor)/error.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+export default function TutorError({ error }: { error: Error }) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-2 bg-slate-50 text-slate-600">
+      <h1 className="text-lg font-semibold text-red-600">튜터 홈을 불러오지 못했습니다.</h1>
+      <p className="text-sm">{error.message}</p>
+    </main>
+  );
+}

--- a/apps/web/app/(tutor)/loading.tsx
+++ b/apps/web/app/(tutor)/loading.tsx
@@ -1,0 +1,7 @@
+export default function TutorLoading() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-slate-50 text-slate-500">
+      <p role="status">튜터 대시보드를 준비하는 중…</p>
+    </main>
+  );
+}

--- a/apps/web/app/(tutor)/page.tsx
+++ b/apps/web/app/(tutor)/page.tsx
@@ -1,0 +1,49 @@
+import { DecisionCard } from '@/components/DecisionCard';
+import { StatPanel } from '@/components/StatPanel';
+import { getTutorDashboard } from '@/lib/api';
+
+export default async function TutorHome() {
+  const data = await getTutorDashboard();
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-4xl flex-col gap-6 px-6 py-8">
+      <header className="rounded-lg bg-white p-6 shadow-sm">
+        <h1 className="text-2xl font-semibold text-slate-900">피드백 대기함</h1>
+        <p className="mt-1 text-sm text-slate-600">SLA 타이머를 지키기 위해 가장 오래 기다린 제출부터 처리하세요.</p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <StatPanel label="대기 중" value={`${data.reviewQueue.length}건`} />
+        <StatPanel label="오늘 세션" value={`${data.todaysSessions.length}건`} />
+      </section>
+
+      <section className="space-y-3">
+        {data.reviewQueue.length > 0 ? (
+          data.reviewQueue.map((item) => (
+            <DecisionCard
+              key={item.id}
+              title={item.title}
+              description={`${item.studentName} · 상태 ${item.status}`}
+              actionLabel="1-click 피드백"
+              href={`/assignments/${item.id}`}
+            />
+          ))
+        ) : (
+          <p className="rounded-lg bg-slate-100 p-4 text-sm text-slate-600" role="status">
+            검토 대기 중인 제출이 없습니다.
+          </p>
+        )}
+      </section>
+
+      <DecisionCard
+        title="새 과제 생성"
+        description="목표와 모범 답안을 지정하고 즉시 공유하세요."
+        actionLabel="과제 작성"
+        href="/assignments/new"
+        variant="secondary"
+      />
+
+      {data.message ? <p className="text-sm text-amber-600">{data.message}</p> : null}
+    </main>
+  );
+}

--- a/apps/web/app/assignments/[id]/page.tsx
+++ b/apps/web/app/assignments/[id]/page.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link';
+import { getAssignmentDetail } from '@/lib/api';
+import { DecisionCard } from '@/components/DecisionCard';
+
+export default async function AssignmentDetail({ params }: { params: { id: string } }) {
+  const data = await getAssignmentDetail(params.id);
+
+  if (data.assignment === null) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center bg-slate-50 text-slate-600">
+        <p>해당 과제를 찾을 수 없습니다.</p>
+        <Link href="/student" className="mt-4 text-primary underline">
+          학생 홈으로 돌아가기
+        </Link>
+      </main>
+    );
+  }
+
+  const submissions = (data.assignment?.submissions as Array<Record<string, unknown>>) ?? [];
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col gap-6 px-6 py-8">
+      <header className="rounded-lg bg-white p-6 shadow-sm">
+        <h1 className="text-2xl font-semibold text-slate-900">{data.assignment?.title}</h1>
+        <p className="mt-2 text-sm text-slate-600">목표: {data.assignment?.goal}</p>
+        <p className="mt-1 text-xs uppercase tracking-wide text-slate-400">상태: {data.assignment?.status}</p>
+      </header>
+
+      <section className="rounded-lg bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">제출 기록</h2>
+        {submissions.length > 0 ? (
+          <ol className="mt-3 space-y-3 text-sm text-slate-600">
+            {submissions.map((submission) => (
+              <li key={submission.id as string} className="rounded-md border border-slate-200 p-3">
+                <p className="font-semibold">버전 {submission.version as number}</p>
+                <p className="text-xs text-slate-500">상태: {submission.status as string}</p>
+                {submission.comment ? <p className="mt-1">코멘트: {submission.comment as string}</p> : null}
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <p className="mt-2 text-sm text-slate-500">아직 제출한 파일이 없습니다.</p>
+        )}
+      </section>
+
+      <DecisionCard
+        title="파일 재제출"
+        description="보완 요청이 있다면 한 번의 클릭으로 다시 업로드하세요."
+        actionLabel="재제출 준비"
+        href="/student"
+        variant="secondary"
+      />
+
+      {data.message ? <p className="text-xs text-amber-600">{data.message}</p> : null}
+    </main>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-slate-50 text-slate-900;
+}
+
+button:focus {
+  @apply outline-none ring-2 ring-primary ring-offset-2;
+}

--- a/apps/web/app/invoices/[id]/page.tsx
+++ b/apps/web/app/invoices/[id]/page.tsx
@@ -1,0 +1,63 @@
+import Link from 'next/link';
+import { getInvoiceDetail } from '@/lib/api';
+
+const API_BASE = process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+
+export default async function InvoiceDetail({ params }: { params: { id: string } }) {
+  const data = await getInvoiceDetail(params.id);
+
+  if (data.invoice === null) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center bg-slate-50 text-slate-600">
+        <p>청구서를 찾을 수 없습니다.</p>
+        <Link href="/parent" className="mt-4 text-primary underline">
+          부모 홈으로 돌아가기
+        </Link>
+      </main>
+    );
+  }
+
+  const items = (data.invoice?.lineItems as Array<{ type: string; qty: number; unitPrice: number }>) ?? [];
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-2xl flex-col gap-6 px-6 py-8">
+      <header className="rounded-lg bg-white p-6 shadow-sm">
+        <h1 className="text-2xl font-semibold text-slate-900">청구서 #{data.invoice?.id}</h1>
+        <p className="mt-1 text-sm text-slate-600">청구 기간: {data.invoice?.period}</p>
+        <p className="mt-1 text-xs uppercase tracking-wide text-slate-400">상태: {data.invoice?.status}</p>
+      </header>
+
+      <section className="rounded-lg bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">라인 아이템</h2>
+        <table className="mt-3 w-full text-sm text-slate-600">
+          <thead>
+            <tr className="text-left text-xs uppercase tracking-wide text-slate-400">
+              <th className="py-2">유형</th>
+              <th className="py-2">수량</th>
+              <th className="py-2">단가</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item, index) => (
+              <tr key={`${item.type}-${index}`} className="border-t border-slate-100">
+                <td className="py-2 capitalize">{item.type}</td>
+                <td className="py-2">{item.qty}</td>
+                <td className="py-2">${item.unitPrice}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p className="mt-4 text-right text-lg font-semibold text-slate-900">총액: ${data.invoice?.total}</p>
+      </section>
+
+      <Link
+        href={`${API_BASE}/invoices/${params.id}/receipt`}
+        className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
+      >
+        영수증 다운로드
+      </Link>
+
+      {data.message ? <p className="text-xs text-amber-600">{data.message}</p> : null}
+    </main>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,19 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { ReactNode } from 'react';
+import { Inter } from 'next/font/google';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata: Metadata = {
+  title: 'Tutor Loop Hub',
+  description: 'Keep students, parents, and tutors aligned in one-click screens.'
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" className="h-full">
+      <body className={`${inter.className} min-h-screen bg-slate-50`}>{children}</body>
+    </html>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+
+export default function LandingPage() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-4xl flex-col gap-6 px-6 py-12">
+      <section className="rounded-2xl bg-white p-8 shadow">
+        <h1 className="text-3xl font-bold text-slate-900">Tutor Loop Hub</h1>
+        <p className="mt-2 text-slate-600">
+          Connect students, parents, and tutors with transparent loops for assignments, schedules, and visibility. Use the role
+          dashboards below for “one screen, one decision” control.
+        </p>
+      </section>
+      <section className="grid gap-4 md:grid-cols-3">
+        <Link
+          href="/student"
+          className="rounded-lg border border-slate-200 bg-white p-4 text-center shadow transition hover:border-primary hover:shadow-lg"
+        >
+          <h2 className="text-lg font-semibold">학생 홈</h2>
+          <p className="mt-1 text-sm text-slate-500">오늘 할 일과 제출 버튼</p>
+        </Link>
+        <Link
+          href="/tutor"
+          className="rounded-lg border border-slate-200 bg-white p-4 text-center shadow transition hover:border-primary hover:shadow-lg"
+        >
+          <h2 className="text-lg font-semibold">튜터 홈</h2>
+          <p className="mt-1 text-sm text-slate-500">피드백 SLA와 세션 보드</p>
+        </Link>
+        <Link
+          href="/parent"
+          className="rounded-lg border border-slate-200 bg-white p-4 text-center shadow transition hover:border-primary hover:shadow-lg"
+        >
+          <h2 className="text-lg font-semibold">부모 홈</h2>
+          <p className="mt-1 text-sm text-slate-500">하루 1분 요약과 서명 요청</p>
+        </Link>
+      </section>
+      <p className="text-xs text-slate-400">
+        연결된 API 토큰이 없으면 데모 데이터가 표시됩니다. 환경 변수 NEXT_PUBLIC_* 토큰을 설정하여 실데이터를 로드하세요.
+      </p>
+    </main>
+  );
+}

--- a/apps/web/components/DecisionCard.tsx
+++ b/apps/web/components/DecisionCard.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import Link from 'next/link';
+import { useTransition } from 'react';
+import { clsx } from 'clsx';
+
+type DecisionCardProps = {
+  title: string;
+  description: string;
+  actionLabel: string;
+  href?: string;
+  onClick?: () => Promise<void> | void;
+  variant?: 'primary' | 'secondary';
+  disabled?: boolean;
+};
+
+export function DecisionCard({ title, description, actionLabel, href, onClick, variant = 'primary', disabled }: DecisionCardProps) {
+  const [pending, startTransition] = useTransition();
+  const actionable = !disabled && !pending;
+  const commonButtonClasses = clsx(
+    'rounded-md px-4 py-2 text-sm font-semibold text-white shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+    variant === 'primary' ? 'bg-primary hover:bg-blue-700 focus-visible:outline-primary' : 'bg-slate-700 hover:bg-slate-800 focus-visible:outline-slate-700',
+    (disabled || pending) && 'cursor-not-allowed opacity-60'
+  );
+
+  const content = (
+    <button
+      type="button"
+      aria-label={actionLabel}
+      className={commonButtonClasses}
+      disabled={!actionable}
+      onClick={
+        onClick
+          ? () => {
+              if (!actionable) return;
+              startTransition(async () => {
+                await onClick();
+              });
+            }
+          : undefined
+      }
+    >
+      {pending ? 'Loading…' : actionLabel}
+    </button>
+  );
+
+  return (
+    <section className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+      <header>
+        <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+        <p className="mt-1 text-sm text-slate-600">{description}</p>
+      </header>
+      <div className="mt-2">
+        {href ? (
+          <Link href={href} className="inline-block" aria-label={actionLabel}>
+            {content}
+          </Link>
+        ) : (
+          content
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/StatPanel.tsx
+++ b/apps/web/components/StatPanel.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+export function StatPanel({ label, value, icon }: { label: string; value: ReactNode; icon?: ReactNode }) {
+  return (
+    <div className="flex flex-col rounded-lg border border-slate-100 bg-white p-4 shadow-sm">
+      <span className="text-xs uppercase tracking-wide text-slate-500">{label}</span>
+      <div className="mt-1 flex items-center gap-2 text-lg font-semibold text-slate-900">
+        {icon}
+        <span>{value}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,0 +1,198 @@
+const API_URL = process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+
+type FetchOptions = {
+  token?: string;
+  cache?: RequestCache;
+};
+
+async function safeFetch<T>(path: string, options: FetchOptions = {}): Promise<{ data: T | null; error?: string }> {
+  try {
+    const res = await fetch(`${API_URL}${path}`, {
+      cache: options.cache ?? 'no-store',
+      headers: options.token
+        ? {
+            Authorization: `Bearer ${options.token}`
+          }
+        : undefined
+    });
+    if (!res.ok) {
+      return { data: null, error: `${res.status} ${res.statusText}` };
+    }
+    const data = (await res.json()) as T;
+    return { data };
+  } catch (error) {
+    return { data: null, error: (error as Error).message };
+  }
+}
+
+type StudentDashboard = {
+  pendingAssignments: Array<{ id: string; title: string; dueAt: string }>;
+  latestEncouragement?: string;
+  message?: string;
+};
+
+export async function getStudentDashboard(): Promise<StudentDashboard> {
+  const studentId = process.env.NEXT_PUBLIC_STUDENT_ID;
+  const token = process.env.NEXT_PUBLIC_STUDENT_TOKEN;
+
+  if (!studentId || !token) {
+    return {
+      pendingAssignments: [
+        { id: 'demo-assignment', title: 'Write reflection on chapter 3', dueAt: new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString() }
+      ],
+      latestEncouragement: '부모님: 오늘도 파이팅! (Demo)',
+      message: 'Connect API credentials to view live submissions.'
+    };
+  }
+
+  const assignments = await safeFetch<{ assignments: Array<{ assignment: { id: string; title: string; dueAt: string } }> }>(
+    `/assignments/students/${studentId}`,
+    { token }
+  );
+
+  if (!assignments.data) {
+    return {
+      pendingAssignments: [],
+      message: assignments.error ?? 'Unable to reach API'
+    };
+  }
+
+  return {
+    pendingAssignments: assignments.data.assignments.map((entry) => ({
+      id: entry.assignment.id,
+      title: entry.assignment.title,
+      dueAt: entry.assignment.dueAt
+    })),
+    latestEncouragement: 'Keep going! 연결된 격려는 API 활성화 시 표시됩니다.'
+  };
+}
+
+type TutorDashboard = {
+  reviewQueue: Array<{ id: string; title: string; studentName: string; status: string }>;
+  todaysSessions: Array<{ id: string; start: string; end: string }>;
+  message?: string;
+};
+
+export async function getTutorDashboard(): Promise<TutorDashboard> {
+  const tutorToken = process.env.NEXT_PUBLIC_TUTOR_TOKEN;
+  const studentId = process.env.NEXT_PUBLIC_STUDENT_ID;
+  if (!tutorToken || !studentId) {
+    return {
+      reviewQueue: [
+        { id: 'demo', title: 'Essay draft', studentName: 'Student S', status: 'Waiting 3h' }
+      ],
+      todaysSessions: [],
+      message: 'Add NEXT_PUBLIC_TUTOR_TOKEN to stream live SLA timers.'
+    };
+  }
+
+  const assignments = await safeFetch<{ assignments: Array<{ assignment: { id: string; title: string; status: string }; scope: string }> }>(
+    `/assignments/students/${studentId}`,
+    { token: tutorToken }
+  );
+
+  const reviewQueue = assignments.data
+    ? assignments.data.assignments
+        .filter((entry) => entry.assignment.status !== 'Finalized')
+        .map((entry) => ({ id: entry.assignment.id, title: entry.assignment.title, studentName: 'Your student', status: entry.assignment.status }))
+    : [];
+
+  return {
+    reviewQueue,
+    todaysSessions: [],
+    message: assignments.error
+  };
+}
+
+type ParentDashboard = {
+  digest?: {
+    highlights: unknown;
+    risks: unknown;
+    next: unknown;
+  };
+  message?: string;
+};
+
+export async function getParentDashboard(): Promise<ParentDashboard> {
+  const parentToken = process.env.NEXT_PUBLIC_PARENT_TOKEN;
+  const studentId = process.env.NEXT_PUBLIC_STUDENT_ID;
+  if (!parentToken || !studentId) {
+    return {
+      digest: {
+        highlights: {
+          demo: '최신 제출과 세션 요약은 API 연결 시 노출됩니다.'
+        },
+        risks: {
+          due_in_48h_without_submission: ['Demo Essay']
+        },
+        next: {
+          next_due: { title: 'Vocabulary quiz', dueAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString() }
+        }
+      },
+      message: 'Set NEXT_PUBLIC_PARENT_TOKEN and NEXT_PUBLIC_STUDENT_ID for live visibility.'
+    };
+  }
+
+  const digest = await safeFetch<{ highlights: unknown; risks: unknown; next: unknown }>(
+    `/daily-digest?relationship=S-P&studentId=${studentId}`,
+    { token: parentToken }
+  );
+
+  if (!digest.data) {
+    return { message: digest.error };
+  }
+
+  return { digest: digest.data };
+}
+
+export async function getAssignmentDetail(assignmentId: string) {
+  const studentId = process.env.NEXT_PUBLIC_STUDENT_ID;
+  const token = process.env.NEXT_PUBLIC_STUDENT_TOKEN ?? process.env.NEXT_PUBLIC_TUTOR_TOKEN;
+
+  if (!studentId || !token) {
+    return {
+      assignment: {
+        id: assignmentId,
+        title: 'Demo Assignment',
+        goal: '환경 설정 후 API 연결',
+        status: 'Open',
+        submissions: []
+      },
+      message: 'API 토큰을 설정하면 실제 데이터가 표시됩니다.'
+    };
+  }
+
+  const assignments = await safeFetch<{ assignments: Array<{ assignment: Record<string, unknown> }> }>(`/assignments/students/${studentId}`, {
+    token
+  });
+
+  const match = assignments.data?.assignments.find((entry) => entry.assignment.id === assignmentId)?.assignment;
+  if (!match) {
+    return { message: 'Assignment not found', assignment: null };
+  }
+
+  return { assignment: match, message: assignments.error };
+}
+
+export async function getInvoiceDetail(invoiceId: string) {
+  const token = process.env.NEXT_PUBLIC_PARENT_TOKEN ?? process.env.NEXT_PUBLIC_TUTOR_TOKEN;
+  if (!token) {
+    return {
+      invoice: {
+        id: invoiceId,
+        period: '2024-05',
+        status: 'Issued',
+        lineItems: [{ type: 'tuition', qty: 180, unitPrice: 1.2 }],
+        total: '216.00'
+      },
+      message: 'API 토큰을 설정하면 실제 청구서가 표시됩니다.'
+    };
+  }
+
+  const invoice = await safeFetch<{ invoice: Record<string, unknown> }>(`/invoices/${invoiceId}`, { token });
+  if (!invoice.data) {
+    return { invoice: null, message: invoice.error };
+  }
+
+  return { invoice: invoice.data.invoice, message: invoice.error };
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@start/web",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "clsx": "2.1.0",
+    "date-fns": "3.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.30",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.1.0",
+    "postcss": "8.4.31",
+    "tailwindcss": "3.4.1",
+    "typescript": "5.4.2"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,16 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#1D4ED8',
+        accent: '#F97316'
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "allowJs": false,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
+    "paths": {
+      "@/lib/*": ["./lib/*"],
+      "@/components/*": ["./components/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: start
+      POSTGRES_PASSWORD: start
+      POSTGRES_DB: start
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "start-monorepo",
+  "private": true,
+  "version": "1.0.0",
+  "workspaces": [
+    "apps/api",
+    "apps/web"
+  ],
+  "scripts": {
+    "build": "npm run build -w apps/api && npm run build -w apps/web",
+    "dev:api": "npm run dev -w apps/api",
+    "dev:web": "npm run dev -w apps/web",
+    "lint": "npm run lint -w apps/api && npm run lint -w apps/web",
+    "test": "npm run test -w apps/api",
+    "prisma:migrate": "npm run prisma:migrate -w apps/api",
+    "prisma:seed": "npm run prisma:seed -w apps/api"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "allowJs": false,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Summary
- stand up the Express + Prisma API covering authentication, assignments/submissions with SLA tracking, calendar, attendance, invoices/reports, digests, visibility, and audit logging
- add Prisma schema, initial migration, docker-compose Postgres config, and seed data for tutor/parent/student loops
- build Next.js 14 role dashboards, shared UI components, and Supertest integration tests validating the S↔T, P↔T, and S↔P flows

## Testing
- npm install *(fails: 403 Forbidden while fetching @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68cb9622bd08832a9ecf19fcbd2b5938